### PR TITLE
Removed tech-seed from README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,11 @@ sudo apt update
 sudo apt install redis 
 ```
 
-**6. Run medusa seed & migrations** 
+**6. Run medusa seed** 
 
-```medusa seed --seed-file=data/seed.json
-# or npx medusa seed --seed-file=data/seed.json
+```
 cd ./hamza-server
 npx medusa seed --seed-file=data/seed.json
-npx medusa seed --seed-file=data/tech_seed.json 
 npx medusa migrations run
 ```
 


### PR DESCRIPTION
Removed tech-seed from README setup instructions, so that interviewees aren't confused by the extra instruction. 