### PR TITLE
fix (issue-11): Fixed @medusajs/medusa version to 1.20.2

### DIFF
--- a/hamza-client/package.json
+++ b/hamza-client/package.json
@@ -43,7 +43,7 @@
     "framer-motion": "^11.0.8",
     "iron-session": "^8.0.1",
     "lodash": "^4.17.21",
-    "medusa-react": "^9.0.13",
+    "medusa-react": "9.0.15",
     "next": "^14.1.1-canary.12",
     "oracledb": "^6.3.0",
     "pg-query-stream": "^4.5.3",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@medusajs/client-types": "^0.2.2",
-    "@medusajs/medusa": "^1.20.0",
+    "@medusajs/medusa": "1.20.2",
     "@medusajs/ui-preset": "^1.0.2",
     "@types/lodash": "^4.14.195",
     "@types/node": "17.0.21",


### PR DESCRIPTION
## Intro and instructions

This PR refers to #11 - Follow the instructions in the ticket to replicate the error.

For this specific PR is needed to do the following:

into `hamza-client` folder:

```bash
  rm -rf node_modules .next yarn.lock
  yarn install
  yarn dev
```  

**⚠️ Note**:

To prevent `error:   Cart with cart_XXXXXXXXXXXXXXXXXXXXXX was not found` clear your browser data, local storage, cookies and session storage and refresh the page.

## Description:

I had to freeze the versions of medusa-react and @medusajs/medusa, as newer versions were causing conflicts in the orchestration and workflows packages.

This is like a hotfix for the current problem, However, I strongly suggest upgrading `@medusajs/medusa` to the newer version v1.20.4 (in both sides client and server). This change requires some extra packages upgrades and migrations that may corrupt the current data, so it needs to be done and tested properly.