### PR TITLE
Initial order status

### DIFF
--- a/hamza-server/src/api/custom/checkout/route.ts
+++ b/hamza-server/src/api/custom/checkout/route.ts
@@ -42,7 +42,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         //enforce security
         if (!handler.enforceCustomerId(cart.customer_id)) return;
 
-        const orders = await orderService.getOrdersForCart(cartId);
+        const orders = await orderService.getOrdersForCheckout(cartId);
         const output: ICheckoutData[] = [];
         orders.forEach((o) => {
             output.push({

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -123,11 +123,17 @@ export default class OrderService extends MedusaOrderService {
         return null;
     }
 
-    async getOrdersForCart(cartId: string): Promise<Order[]> {
-        return await this.orderRepository_.find({
-            where: { cart_id: cartId, status: OrderStatus.PENDING },
+    async getOrdersForCheckout(cartId: string): Promise<Order[]> {
+        const orders = await this.orderRepository_.find({
+            where: { cart_id: cartId, status: OrderStatus.REQUIRES_ACTION },
             relations: ['store.owner', 'payments'],
+            skip: 0,
+            take: 1,
+            order: { created_at: "DESC" }
         });
+
+        console.log('GET ORDERS FOR CHECKOUT: ', orders.length)
+        return orders;
     }
 
     async getOrderWithStore(orderId: string): Promise<Order> {
@@ -297,7 +303,7 @@ export default class OrderService extends MedusaOrderService {
     }
 
     async getCustomerOrders(customerId: string): Promise<Order[]> {
-        return await this.orderRepository_.find({
+        const orders = await this.orderRepository_.find({
             where: {
                 customer_id: customerId,
                 status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -124,16 +124,13 @@ export default class OrderService extends MedusaOrderService {
     }
 
     async getOrdersForCheckout(cartId: string): Promise<Order[]> {
-        const orders = await this.orderRepository_.find({
+        return await this.orderRepository_.find({
             where: { cart_id: cartId, status: OrderStatus.REQUIRES_ACTION },
             relations: ['store.owner', 'payments'],
             skip: 0,
             take: 1,
             order: { created_at: "DESC" }
         });
-
-        console.log('GET ORDERS FOR CHECKOUT: ', orders.length)
-        return orders;
     }
 
     async getOrderWithStore(orderId: string): Promise<Order> {
@@ -303,7 +300,7 @@ export default class OrderService extends MedusaOrderService {
     }
 
     async getCustomerOrders(customerId: string): Promise<Order[]> {
-        const orders = await this.orderRepository_.find({
+        return await this.orderRepository_.find({
             where: {
                 customer_id: customerId,
                 status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),

--- a/hamza-server/src/services/order.ts
+++ b/hamza-server/src/services/order.ts
@@ -98,6 +98,7 @@ export default class OrderService extends MedusaOrderService {
             order.sales_channel_id = cart.sales_channel_id;
             order.total = payment.amount;
             order.updated_at = payment.updated_at;
+            order.status = OrderStatus.REQUIRES_ACTION;
 
             //save the order
             order = await this.orderRepository_.save(order);
@@ -253,7 +254,7 @@ export default class OrderService extends MedusaOrderService {
         });
 
         //set order status
-        if (order.status === OrderStatus.PENDING) {
+        if (order.status === OrderStatus.PENDING || order.status === OrderStatus.REQUIRES_ACTION) {
             order.status = OrderStatus.CANCELED;
 
             await this.orderRepository_.save(order);
@@ -273,7 +274,7 @@ export default class OrderService extends MedusaOrderService {
 
     async cancelOrderFromCart(cart_id: string) {
         await this.orderRepository_.update(
-            { status: OrderStatus.PENDING, cart: { id: cart_id } },
+            { status: OrderStatus.REQUIRES_ACTION, cart: { id: cart_id } },
             { status: OrderStatus.ARCHIVED }
         );
     }
@@ -299,7 +300,7 @@ export default class OrderService extends MedusaOrderService {
         return await this.orderRepository_.find({
             where: {
                 customer_id: customerId,
-                status: Not(OrderStatus.ARCHIVED),
+                status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),
             },
             relations: ['cart.items', 'cart', 'cart.items.variant.product'],
         });
@@ -366,7 +367,7 @@ export default class OrderService extends MedusaOrderService {
         items: any[];
     }> {
         const orders = (await this.orderRepository_.find({
-            where: { cart_id: cartId, status: Not(OrderStatus.ARCHIVED) },
+            where: { cart_id: cartId, status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])) },
             relations: ['cart.items.variant.product', 'store.owner'],
         })) as Order[];
 
@@ -444,7 +445,7 @@ export default class OrderService extends MedusaOrderService {
         const orders = await this.orderRepository_.find({
             where: {
                 customer_id: customerId,
-                status: Not(OrderStatus.ARCHIVED),
+                status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),
             },
             select: ['id', 'cart_id'], // Select id and cart_id
             // relations: ['cart.items', 'cart.items.variant'],
@@ -460,7 +461,7 @@ export default class OrderService extends MedusaOrderService {
 
     async getOrderDetails(cartId: string) {
         const orderHandle = await this.orderRepository_.findOne({
-            where: { cart_id: cartId, status: Not(OrderStatus.ARCHIVED) },
+            where: { cart_id: cartId, status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])) },
             relations: ['cart.items', 'cart.items.variant.product', 'cart'],
         });
         let product_handles = [];
@@ -556,7 +557,7 @@ export default class OrderService extends MedusaOrderService {
             fulfillment_status?: any;
         } = {
             customer_id: customerId,
-            status: Not(OrderStatus.ARCHIVED),
+            status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),
         };
 
         if (statusParams.orderStatus) {

--- a/hamza-server/src/services/product-review.ts
+++ b/hamza-server/src/services/product-review.ts
@@ -132,7 +132,7 @@ class ProductReviewService extends TransactionBaseService {
             where: {
                 id: In(unreviewedOrderIds),
                 customer_id: customer_id,
-                status: Not(OrderStatus.ARCHIVED),
+                status: Not(In([OrderStatus.ARCHIVED, OrderStatus.REQUIRES_ACTION])),
             },
             relations: ['items', 'items.variant.product'],
         });

--- a/hamza-server/src/services/product.ts
+++ b/hamza-server/src/services/product.ts
@@ -858,7 +858,7 @@ class CategoryCache extends SeamlessCache {
         return super.retrieve(params);
     }
 
-    protected async getData(productCategoryRepository: any): Promise<any> {
+    protected async getData(productCategoryRepository: any): Promise<ProductCategory[]> {
         return await productCategoryRepository.find({
             select: ['id', 'name', 'metadata'],
             relations: [


### PR DESCRIPTION
- initial order status is now REQUIRES_ACTION (unused status)
- only the most recent order is retrieved from checkout 
- that cancelling failed order from the frontend is now no longer necessary (but not removed)
- failed orders that weren't cancelled for whatever reason will no longer show up in customer orders