### PR TITLE
Fix: Wrong Product Image Showing

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/preview-checkout.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/preview-checkout.tsx
@@ -138,6 +138,8 @@ const PreviewCheckout: React.FC<PreviewCheckoutProps> = ({
     }, [options]);
 
     useEffect(() => {
+        // clean setSelectedVariantImage
+        setSelectedVariantImage('');
         if (productData && productData.variants) {
             if (!variantId) {
                 // Initially setting the variantId if it's not set


### PR DESCRIPTION
Wrong Product Image Showing fixed by resetting state in parent component 