### PR TITLE
improvement to payment verification: a starting block number is no lo…

### DIFF
--- a/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping-address/index.tsx
@@ -124,7 +124,7 @@ const ShippingAddress = ({
                         required
                     />
                     <Input
-                        label="Aparment, suite, etc"
+                        label="Apartment, suite, etc"
                         name="shipping_address.address_2"
                         autoComplete="address-line2"
                         value={formData['shipping_address.address_2']}

--- a/hamza-server/src/api/admin/custom/payments/verify/route.ts
+++ b/hamza-server/src/api/admin/custom/payments/verify/route.ts
@@ -17,10 +17,14 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         const buckydropService: BuckydropService = req.scope.resolve('buckydropService')
 
         //me minana banana
-        if (handler.hasParam('order_id'))
+        if (handler.hasParam('order_id')) {
+            handler.logger.info(`Verifying payments for ${handler.inputParams.order_id}...`);
             orderPayments = await paymentVerificationService.verifyPayments(handler.inputParams.order_id);
-        else
+        }
+        else {
+            handler.logger.info(`Verifying payments...`);
             orderPayments = await paymentVerificationService.verifyPayments();
+        }
 
         //if orders are bucky orders, we gotta do something
         for (let item of orderPayments) {

--- a/hamza-server/src/web3/contracts/lite-switch.ts
+++ b/hamza-server/src/web3/contracts/lite-switch.ts
@@ -27,12 +27,19 @@ export class LiteSwitchClient {
         );
     }
 
-    async findPaymentEvents(orderId): Promise<{ orderId: string, amount: BigNumberish }[]> {
+    async findPaymentEvents(orderId: string, transactionId: string):
+        Promise<{ orderId: string, amount: BigNumberish }[]> {
+
         const orderIdHash = ethers.keccak256(ethers.toUtf8Bytes(orderId));
         const eventFilter = this.switchClient.filters.PaymentReceived();
 
-        const startingBlock = process.env.TX_VERIFY_START_BLOCK;
-        const events = await this.switchClient.queryFilter(eventFilter, startingBlock, "latest");
+        const txReceipt = await this.provider.getTransactionReceipt(transactionId);
+
+        const events = await this.switchClient.queryFilter(
+            eventFilter,
+            txReceipt.blockNumber,
+            txReceipt.blockNumber + 1
+        );
 
         return events.map(e => {
             const event = e as any;

--- a/hamza-server/src/web3/index.ts
+++ b/hamza-server/src/web3/index.ts
@@ -2,14 +2,24 @@ import { BigNumberish } from 'ethers';
 import { LiteSwitchClient } from './contracts/lite-switch';
 
 
-export async function verifyPaymentForOrder(chainId: number, orderId: string, amount: BigNumberish): Promise<boolean> {
-    const total: bigint = await getAmountPaidForOrder(chainId, orderId, amount);
+export async function verifyPaymentForOrder(
+    chainId: number,
+    transactionId: string,
+    orderId: string,
+    amount: BigNumberish
+): Promise<boolean> {
+    const total: bigint = await getAmountPaidForOrder(chainId, transactionId, orderId, amount);
     return (total >= BigInt(amount));
 }
 
-export async function getAmountPaidForOrder(chainId: number, orderId: string, amount: BigNumberish): Promise<bigint> {
+export async function getAmountPaidForOrder(
+    chainId: number,
+    transactionId: string,
+    orderId: string,
+    amount: BigNumberish
+): Promise<bigint> {
     const switchClient = new LiteSwitchClient(chainId);
-    const events = await switchClient.findPaymentEvents(orderId);
+    const events = await switchClient.findPaymentEvents(orderId, transactionId);
     //console.log('events: ', events);
 
     let total: bigint = BigInt(0);


### PR DESCRIPTION
An improvement to payment verification to reduce the search area for payment events. 
The block number is in the transaction receipt; so only one block need be searched for events. 
Also changed misspelled "arparmetsn" on the frontend to "arapament" 