### PR TITLE
fix for wishlist variant price: price should match the selected variant

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/product-info.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/product-info.tsx
@@ -18,7 +18,7 @@ import { Variant } from 'types/medusa';
 
 const ProductInfo = () => {
     // Zustand
-    const { productData, variantId, quantity, setVariantId } =
+    let { productData, variantId, quantity, setVariantId } =
         useProductPreview();
     const { wishlist } = useWishlistStore();
     const { addWishlistItemMutation, removeWishlistItemMutation } =
@@ -44,17 +44,12 @@ const ProductInfo = () => {
 
     useEffect(() => {
         if (productData && productData.variants) {
-            if (!variantId) {
-                console.log(`variantId in PreviewCheckout comp is not set yet`);
-                setVariantId(productData.variants[0].id);
-            }
+            variantId = variantId ?? productData?.variants[0]?.id;
+            setVariantId(variantId ?? '');
+
             let selectedProductVariant = productData.variants.find(
-                (a: any) => a.id == productData.variants[0]?.id
-                // (a: any) => a.id == variantId
+                (a: any) => a.id == variantId
             );
-            if (!variantId) {
-                setVariantId(selectedProductVariant.id);
-            }
 
             setSelectedVariant(selectedProductVariant);
             const price =
@@ -64,7 +59,6 @@ const ProductInfo = () => {
                         p.currency_code === (preferred_currency_code ?? 'usdc')
                 ));
             setSelectedPrice(price?.amount ?? 0);
-            // console.log(productData);
         }
     }, [productData, variantId]);
 

--- a/hamza-client/src/modules/products/components/product-preview/components/product-info.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/product-info.tsx
@@ -81,8 +81,6 @@ const ProductInfo = () => {
         );
     }
 
-    console.log('this is selected price', selectedPrice);
-
     return (
         <Flex
             width="100%"

--- a/hamza-client/src/store/wishlist/mutations/wishlist-mutations.tsx
+++ b/hamza-client/src/store/wishlist/mutations/wishlist-mutations.tsx
@@ -43,7 +43,7 @@ export function useWishlistMutations() {
         {
             onSuccess: (data, product) => {
                 // loadWishlist(customer_id);
-                console.log('Adding Wish list item in DB!');
+                console.log('Adding Wish list item ', product.productVariantId, ' in DB!');
             },
             onError: (error, product) => {
                 removeWishlistProduct(product.productVariantId ?? '');

--- a/hamza-client/src/store/wishlist/mutations/wishlist-mutations.tsx
+++ b/hamza-client/src/store/wishlist/mutations/wishlist-mutations.tsx
@@ -46,7 +46,7 @@ export function useWishlistMutations() {
                 console.log('Adding Wish list item ', product.productVariantId, ' in DB!');
             },
             onError: (error, product) => {
-                removeWishlistProduct(product.productVariantId ?? '');
+                removeWishlistProduct(product.id ?? '');
                 console.error('Error adding item to wishlist', error);
             },
         }
@@ -55,7 +55,7 @@ export function useWishlistMutations() {
     const removeWishlistItemMutation = useMutation(
         (product: WishlistProduct) => {
             // Return the axios delete call from the mutation function
-            removeWishlistProduct(product.productVariantId ?? '');
+            removeWishlistProduct(product.id ?? '');
             //TODO: MOVE TO INDEX.TS
             return axios.delete(`${BACKEND_URL}/custom/wishlist/item`, {
                 data: {

--- a/hamza-client/src/store/wishlist/wishlist-store.tsx
+++ b/hamza-client/src/store/wishlist/wishlist-store.tsx
@@ -62,15 +62,15 @@ const useWishlistStore = create<WishlistType>()(
                     },
                 }));
             },
-            removeWishlistProduct: async (productVariantId) => {
+            removeWishlistProduct: async (productId) => {
                 console.log(
-                    'Attempting to remove product variant with ID:',
-                    productVariantId
+                    'Attempting to remove product with ID:',
+                    productId
                 );
                 const { wishlist } = get();
                 set((state) => {
                     const filteredItems = wishlist.products.filter(
-                        (p) => p.productVariantId !== productVariantId
+                        (p) => p.id !== productId
                     );
                     console.log('Filtered items:', filteredItems);
                     return {
@@ -130,52 +130,6 @@ const useWishlistStore = create<WishlistType>()(
             // Optional: You can trigger loadWishlist after the store has been rehydrated from localStorage
             onRehydrateStorage: () => (state, error) => {
                 console.log('Rehydration process triggered');
-                /*
-                if (error) {
-                    console.error('Rehydration error:', error);
-                    return;
-                }
-                // console.log(
-                //     'Rehydration successful, checking for customer data...'
-                // );
-                const customerData = localStorage.getItem('__hamza_customer');
-                if (customerData) {
-                    const parsedData = JSON.parse(customerData);
-                    if (parsedData.state.status === 'authenticated') {
-                        console.log('Customer now authenticated');
-                        try {
-                            state?.updateAuthentication(true);
-                            const customer_id = parsedData.state.customer_id;
-                            if (customer_id) {
-                                console.log(
-                                    'Customer ID found:',
-                                    customer_id,
-                                    'Loading wishlist...'
-                                );
-                                state?.loadWishlist(customer_id);
-                            }
-                        } catch (parseError) {
-                            console.error(
-                                'Error parsing customer data:',
-                                parseError
-                            );
-                        }
-                    } else if (parsedData.state.status === 'unauthenticated') {
-                        try {
-                            state?.updateAuthentication(false);
-                        } catch (e) {
-                            console.log(`Couldn't unauthenticate, ${e}`);
-                        }
-                        console.log(`Customer is now unauthenticated`);
-                    } else {
-                        console.log(
-                            'No customer data found, possibly new session'
-                        );
-                    }
-                } else {
-                    console.log('No customer data found in local storage.');
-                }
-                */
             },
         }
     )


### PR DESCRIPTION
The correct variant is indeed being added to the wishlist. 
But the price associated with it is always the price of the first variant; that's fixed.
When a variant is removed from wishlist, it's removed by product id. This removed the bug in which the item won't remove itself unless you select the correct variant before removing it.