### PR TITLE
[LHF] Back to products behavior

### DIFF
--- a/hamza-client/src/modules/common/components/localized-client-link/index.tsx
+++ b/hamza-client/src/modules/common/components/localized-client-link/index.tsx
@@ -22,6 +22,10 @@ const LocalizedClientLink = ({
 }) => {
     const { countryCode } = useParams();
     const router = useRouter();
+    const baseURL =
+        process.env.NEXT_PUBLIC_MEDUSA_CLIENT_URL || 'http://localhost:8000';
+    // default fallback path should go to homepage just incase they load website on child page...
+    const fallbackPath = countryCode ? `${baseURL}/${countryCode}` : baseURL;
 
     const handleClick = (
         e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -31,8 +35,10 @@ const LocalizedClientLink = ({
         // If href is provided, navigate to it. Otherwise, go back one step in history
         if (href) {
             router.push(`/${countryCode}${href}`);
-        } else {
+        } else if (window.history.length > 1) {
             router.back();
+        } else {
+            router.push(fallbackPath); // Navigate to fallback path if no history exists
         }
     };
 

--- a/hamza-client/src/modules/common/components/localized-client-link/index.tsx
+++ b/hamza-client/src/modules/common/components/localized-client-link/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import React from 'react';
 
 /**
@@ -14,18 +14,36 @@ const LocalizedClientLink = ({
     ...props
 }: {
     children?: React.ReactNode;
-    href: string;
+    href?: string;
     className?: string;
     onClick?: () => void;
     passHref?: true;
     [x: string]: any;
 }) => {
     const { countryCode } = useParams();
+    const router = useRouter();
+
+    const handleClick = (
+        e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+    ) => {
+        e.preventDefault(); // Prevent default anchor behavior
+
+        // If href is provided, navigate to it. Otherwise, go back one step in history
+        if (href) {
+            router.push(`/${countryCode}${href}`);
+        } else {
+            router.back();
+        }
+    };
 
     return (
-        <Link href={`/${countryCode}${href}`} {...props}>
+        <a
+            href={href ? `/${countryCode}${href}` : '#'}
+            onClick={handleClick}
+            {...props}
+        >
             {children}
-        </Link>
+        </a>
     );
 };
 

--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -104,7 +104,7 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
                 width="100%"
                 flexDirection={'row'}
             >
-                <LocalizedClientLink href="/shop">
+                <LocalizedClientLink className="back-button">
                     <Flex
                         ml="-0.5rem"
                         height={'52px'}


### PR DESCRIPTION
Back to Products now goes one route back... 
- LocalizedClientLink edited;
   - href optional now; if not set, router.back gets called.. 
   - Edge case covered: if they have no history and load the page on a random product page... route back to home page. 