### PR TITLE
Show variant image in cart/checkout if available

### DIFF
--- a/hamza-client/src/modules/cart/components/item-checkout/index.tsx
+++ b/hamza-client/src/modules/cart/components/item-checkout/index.tsx
@@ -72,7 +72,7 @@ const Item = ({ item, region, currencyCode }: ItemProps) => {
                         width={{ base: '60px', md: '110px' }}
                         height={{ base: '60px', md: '110px' }}
                     >
-                        <Thumbnail thumbnail={item.thumbnail} size="square" />
+                        <Thumbnail thumbnail={item?.variant?.metadata?.imgUrl ?? item?.thumbnail} size="square" />
                     </Flex>
                 </LocalizedClientLink>
 

--- a/hamza-client/src/modules/cart/components/item/index.tsx
+++ b/hamza-client/src/modules/cart/components/item/index.tsx
@@ -65,7 +65,7 @@ const Item = ({ item, region }: ItemProps) => {
                         width={{ base: '60px', md: '110px' }}
                         height={{ base: '60px', md: '110px' }}
                     >
-                        <Thumbnail thumbnail={item.thumbnail} size="square" />
+                        <Thumbnail thumbnail={item?.variant?.metadata?.imgUrl ?? item?.thumbnail} size="square" />
                     </Flex>
                 </LocalizedClientLink>
 


### PR DESCRIPTION
In cart and checkout, show the product variant image if one is available; otherwise show the product.thumbnail.