### PR TITLE
bug fix: emails must always be lowercase

### DIFF
--- a/hamza-server/src/api/custom/discord/route.ts
+++ b/hamza-server/src/api/custom/discord/route.ts
@@ -60,7 +60,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             await CustomerRepository.update(
                 { id: decoded.customer_id },
                 {
-                    email: userResponse.data.email,
+                    email: userResponse.data?.email?.trim()?.toLowerCase(),
                     is_verified: true,
                     first_name: userResponse.data.global_name.split(' ')[0],
                     last_name:

--- a/hamza-server/src/api/custom/google/route.ts
+++ b/hamza-server/src/api/custom/google/route.ts
@@ -134,7 +134,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         await CustomerRepository.update(
             { id: decoded.customer_id },
             {
-                email: user.email,
+                email: user.email?.trim()?.toLowerCase(),
                 is_verified: true,
                 first_name: user.given_name,
                 last_name: user.family_name,

--- a/hamza-server/src/api/custom/twitter/route.ts
+++ b/hamza-server/src/api/custom/twitter/route.ts
@@ -157,7 +157,7 @@ export async function GET(
         await customerRepository.update(
             { id: decoded.customer_id },
             {
-                email: `${first_name}@${last_name}.com`, //twitterUser?.email,
+                email: `${first_name}@${last_name}.com`?.trim()?.toLowerCase(), //twitterUser?.email,
                 is_verified: true,
                 first_name,
                 last_name,


### PR DESCRIPTION
Fix for a bug that could cause an inability to log in after verifying account: emails from account verification must be lowercase