### PR TITLE
fix for null rating

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/product-info/product-info.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/product-info/product-info.tsx
@@ -77,7 +77,7 @@ const ProductInfo = () => {
 
     // Star Feature
     const renderStars = (rating: any) => {
-        const fullStars = Math.floor(rating);
+        const fullStars = rating ? Math.floor(rating) : 0;
         const halfStar = rating % 1 >= 0.5;
         const emptyStars = 5 - fullStars - (halfStar ? 1 : 0);
 


### PR DESCRIPTION
When there is a null rating, the product details page crashes