### PR TITLE
Twitter oauth fix

### DIFF
--- a/hamza-client/src/modules/account/components/verify/index.tsx
+++ b/hamza-client/src/modules/account/components/verify/index.tsx
@@ -151,6 +151,7 @@ const VerifyEmail = () => {
                 </a>
 
                 {/* Twitter Auth */}
+                {/* 
                 <a href={getTwitterOauthUrl(authParams)}>
                     <Button
                         leftIcon={<FaXTwitter size={24} />}
@@ -167,7 +168,7 @@ const VerifyEmail = () => {
                             <Text mr="auto">Verify with X</Text>
                         </Flex>
                     </Button>
-                </a>
+                </a>*/}
 
                 {/* Discord Auth */}
                 <a

--- a/hamza-server/src/api/custom/twitter/route.ts
+++ b/hamza-server/src/api/custom/twitter/route.ts
@@ -78,7 +78,7 @@ export async function getTwitterUser(
     try {
         // request GET https://api.twitter.com/2/users/me
         const res = await axios.get<{ data: TwitterUser }>(
-            'https://api.twitter.com/2/users/me?user.fields=username,name,id,entities',
+            'https://api.twitter.com/2/users/me?user.fields=username,name,id,email',
             {
                 headers: {
                     'Content-type': 'application/json',

--- a/hamza-server/src/api/custom/twitter/route.ts
+++ b/hamza-server/src/api/custom/twitter/route.ts
@@ -78,7 +78,7 @@ export async function getTwitterUser(
     try {
         // request GET https://api.twitter.com/2/users/me
         const res = await axios.get<{ data: TwitterUser }>(
-            'https://api.twitter.com/2/users/me',
+            'https://api.twitter.com/2/users/me?user.fields=username,name,id,entities',
             {
                 headers: {
                     'Content-type': 'application/json',
@@ -112,12 +112,12 @@ export async function GET(
     await handler.handle(async () => {
         const code = req.query.code;
 
-        handler.logger.debug(`discord oauth cookies: ${JSON.stringify(req.cookies)}`);
+        handler.logger.debug(`twitter oauth cookies: ${JSON.stringify(req.cookies)}`);
         let decoded: any = jwt.decode(req.cookies['_medusa_jwt']);
         handler.logger.debug(
-            `discord oauth decoded _medusa_jwt: ${JSON.stringify(decoded)}`
+            `twitter oauth decoded _medusa_jwt: ${JSON.stringify(decoded)}`
         );
-        handler.logger.debug(`discord oauth req.params: ${JSON.stringify(req.params)}`);
+        handler.logger.debug(`twitter oauth req.params: ${JSON.stringify(req.params)}`);
 
         // 1. get the access token with the code
         const twitterOAuthToken = await getTwitterOAuthToken(code, handler.logger);
@@ -131,6 +131,8 @@ export async function GET(
             twitterOAuthToken.access_token,
             handler.logger
         );
+
+        handler.logger.debug(`Twitter user: ${JSON.stringify(twitterUser)}`);
 
         if (!twitterUser) {
             // redirect if no twitter user


### PR DESCRIPTION
The 'fix' here is to remove the Twitter OAuth button from the site; with our current API access, it doesn't look like we can get the user's email, which is literally all that we want. 
If this changes then I will reenable the button.