### PR TITLE
prevent ghost logins

### DIFF
--- a/hamza-client/src/lib/data/index.ts
+++ b/hamza-client/src/lib/data/index.ts
@@ -825,6 +825,16 @@ export async function clearAuthCookie() {
     }
 }
 
+export async function clearCartCookie() {
+    try {
+        cookies().set('_medusa_cart_id', '', {
+            maxAge: -1,
+        });
+    } catch (e) {
+        console.error(e);
+    }
+}
+
 // Customer actions
 export async function getCustomer() {
     const headers = getMedusaHeaders(['customer']);


### PR DESCRIPTION
This is preventing 'ghost login', which is a phenomenon marked by disconnected wallet, but an active cart and ability to see the account profile page. 
Though I have not seen this issue recently, I do believe it can still happen. And while this change comes with some risk, I think it's worthwhile. 
This only goes through the getCustomer routine in rainbow wrapper if there is a wallet connected.