### PR TITLE
HAMSTR-452 - fix currency selector tests

### DIFF
--- a/hamza-client/cypress/e2e/headed/features/currency-switch.cy.js
+++ b/hamza-client/cypress/e2e/headed/features/currency-switch.cy.js
@@ -26,10 +26,6 @@ describe('Metamask login then user profile', () => {
 
         cy.wait(3000);
 
-        buttonClickByElementText('Save Changes');
-
-        cy.wait(3000);
-
         elementCheckByElementClass('.product-card', {
             findByChild: 'USDC',
             scrollIntoView: false,
@@ -46,10 +42,6 @@ describe('Metamask login then user profile', () => {
             beVisible: false,
             forceClick: true,
         });
-
-        cy.wait(3000);
-
-        buttonClickByElementText('Save Changes');
 
         cy.wait(3000);
 
@@ -72,10 +64,6 @@ describe('Metamask login then user profile', () => {
 
         cy.wait(3000);
 
-        buttonClickByElementText('Save Changes');
-
-        cy.wait(3000);
-
         elementCheckByElementClass('.product-card', {
             findByChild: 'USDT',
             scrollIntoView: false,
@@ -92,10 +80,6 @@ describe('Metamask login then user profile', () => {
             beVisible: false,
             forceClick: true,
         });
-
-        cy.wait(3000);
-
-        buttonClickByElementText('Save Changes');
 
         cy.wait(3000);
 

--- a/hamza-client/src/modules/nav/templates/nav/menu-desktop/wallet-info-menu/currency-selector/index.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-desktop/wallet-info-menu/currency-selector/index.tsx
@@ -42,7 +42,9 @@ const CurrencySelector: React.FC<CurrencySelectorProps> = ({
     usdtBalanceData,
 }) => {
     const authData = useCustomerAuthStore((state) => state.authData);
-    const setCustomerPreferredCurrency = useCustomerAuthStore((state) => state.setCustomerPreferredCurrency);
+    const setCustomerPreferredCurrency = useCustomerAuthStore(
+        (state) => state.setCustomerPreferredCurrency
+    );
 
     useEffect(() => {
         if (!isOpen) {
@@ -100,13 +102,17 @@ const CurrencySelector: React.FC<CurrencySelectorProps> = ({
                             justifyContent="space-between"
                             alignItems="center"
                             cursor="pointer"
+                            className="currency-selector-item"
                             onClick={() => handleCurrencySelection(c.code)}
                         >
                             <Flex alignItems="center" gap="8px">
                                 <Radio
                                     value={c.code}
                                     colorScheme="whiteAlpha"
-                                    _checked={{ bg: 'white', borderColor: 'white' }}
+                                    _checked={{
+                                        bg: 'white',
+                                        borderColor: 'white',
+                                    }}
                                     pointerEvents="none"
                                 />
                                 <Flex alignItems="center" gap="6px">

--- a/hamza-client/src/modules/nav/templates/nav/menu-desktop/wallet-info-menu/index.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-desktop/wallet-info-menu/index.tsx
@@ -109,6 +109,7 @@ const WalletInfo: React.FC<NewWalletInfoProps> = ({
                         flexGrow={0}
                         width="auto"
                         height="48px"
+                        className="currency-selector"
                         p={0}
                     >
                         <Flex


### PR DESCRIPTION
Tests for currency dropdown was broken after changes were made to it.

**TEST**
1. In command line, go to /hamza-medusa/hamza-client
2. Run "npm run cypress"
3. Select E2E Testing -> Chrome -> Start 
4. If you don't have metamask installed in the test browser, install it.
5. Login to metamask
6. Select test to run from left menu:  Specs -> headed / features -> currency-switch.cy.js
7. If you were logged in, metamask will prompt for signing, after that is complete the test will continue to run
8. All tests should run without errors