### PR TITLE
HAMSTR-371: Bitcoin UI

### DIFF
--- a/hamza-client/package.json
+++ b/hamza-client/package.json
@@ -77,6 +77,7 @@
         "react-instantsearch-hooks-web": "^6.29.0",
         "react-intersection-observer": "^9.3.4",
         "react-phone-number-input": "^3.4.3",
+        "react-qr-code": "^2.0.15",
         "sharp": "^0.33.2",
         "siwe": "^2.1.4",
         "tailwindcss-radix": "^2.8.0",

--- a/hamza-client/src/app/[countryCode]/(main)/order/processing/[id]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/order/processing/[id]/page.tsx
@@ -7,7 +7,6 @@ import {
 } from '@medusajs/medusa';
 import { Metadata } from 'next';
 import { buildPaymentsData } from '@/modules/order-processing/utils';
-import { QueryClient } from '@tanstack/react-query';
 
 export const metadata: Metadata = {
     title: 'Order Processing',
@@ -16,6 +15,7 @@ export const metadata: Metadata = {
 
 type Props = {
     params: { id: string };
+    searchParams: { paywith?: string; openqrmodal?: string };
 };
 
 interface BlockchainData {
@@ -88,8 +88,14 @@ export interface PaymentsDataProps {
     orders: Order[];
 }
 
-export default async function ProcessingPage({ params }: Props) {
+export default async function ProcessingPage({ params, searchParams }: Props) {
     const cartId = params.id;
+
+    const paywith = searchParams.paywith;
+    const openqrmodal =
+        !searchParams.openqrmodal || searchParams.paywith !== 'bitcoin'
+            ? 'false'
+            : searchParams.openqrmodal;
 
     const paymentsData = await buildPaymentsData(cartId);
 
@@ -100,6 +106,8 @@ export default async function ProcessingPage({ params }: Props) {
                 endTimestamp={paymentsData.endTimestamp}
                 paymentsData={paymentsData.paymentsData}
                 cartId={cartId}
+                paywith={paywith}
+                openqrmodal={openqrmodal}
             />
         </Container>
     );

--- a/hamza-client/src/modules/checkout/components/discount-code/index.tsx
+++ b/hamza-client/src/modules/checkout/components/discount-code/index.tsx
@@ -80,7 +80,7 @@ const DiscountCode: React.FC<{ cartId?: string }> = ({ cartId }) => {
     if (!cart) return null; // ✅ Hide component if no cart data    const [isOpen, setIsOpen] = React.useState(false);
 
     return (
-        <Flex mt="1rem">
+        <Flex mt="1rem" mb="1rem">
             <div className="txt-medium">
                 {appliedDiscount ? (
                     <div className="w-full flex items-center text-white">

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -8,7 +8,7 @@ import {
     EscrowWalletPaymentHandler,
     AsyncPaymentHandler,
 } from './payment-handlers';
-import { Button } from '@chakra-ui/react';
+import { Box, Button, Divider, Flex, Text, Icon } from '@chakra-ui/react';
 import React, { useState, useEffect } from 'react';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useAccount, useConnect, WindowProvider, useWalletClient } from 'wagmi';
@@ -25,6 +25,7 @@ import { useCartStore } from '@/zustand/cart-store/cart-store';
 import Spinner from '@/modules/common/icons/spinner';
 import { MESSAGES } from './payment-message/message';
 import { useCompleteCartCustom, cancelOrderFromCart } from './useCartMutations';
+import { FaBitcoin } from 'react-icons/fa';
 
 //TODO: we need a global common function to replace this
 
@@ -357,7 +358,7 @@ const CryptoPaymentButton = ({
         if (isCartEmpty) return 'Add products to order';
         if (isMissingAddress) return 'Add address to order';
         if (isUpdating) return <Spinner />;
-        return 'Confirm Order';
+        return 'Pay with Crypto Wallet';
     };
 
     return (
@@ -367,14 +368,43 @@ const CryptoPaymentButton = ({
                 borderRadius={'full'}
                 height={{ base: '42px', md: '58px' }}
                 opacity={1}
-                color={'white'}
+                color={'black'}
                 _hover={{ opacity: 0.5 }}
-                backgroundColor={'primary.indigo.900'}
+                backgroundColor={'primary.green.900'}
                 isLoading={submitting}
                 isDisabled={disableButton}
                 onClick={handlePayment}
             >
                 {getButtonText()}
+            </Button>
+
+            <Flex alignItems="center" my="5px">
+                <Box flex="1">
+                    <Divider borderColor="gray.500" />
+                </Box>
+                <Text mx="4" color="white">
+                    OR
+                </Text>
+                <Box flex="1">
+                    <Divider borderColor="gray.500" />
+                </Box>
+            </Flex>
+
+            <Button
+                borderRadius={'full'}
+                height={{ base: '42px', md: '58px' }}
+                opacity={1}
+                color={'black'}
+                _hover={{ opacity: 0.5 }}
+                backgroundColor={'white'}
+                isLoading={submitting}
+                isDisabled={disableButton}
+                onClick={() => alert('test')}
+            >
+                <Flex alignItems="center" gap={2}>
+                    <Icon as={FaBitcoin} boxSize={7} color="#F7931A" />
+                    Pay with Bitcoin
+                </Flex>
             </Button>
         </>
     );

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -399,7 +399,11 @@ const CryptoPaymentButton = ({
                 backgroundColor={'white'}
                 isLoading={submitting}
                 isDisabled={disableButton}
-                onClick={() => alert('test')}
+                onClick={() =>
+                    router.push(
+                        `/order/processing/${cart.id}?paywith=bitcoin&openqrmodal=true`
+                    )
+                }
             >
                 <Flex alignItems="center" gap={2}>
                     <Icon as={FaBitcoin} boxSize={7} color="#F7931A" />

--- a/hamza-client/src/modules/checkout/templates/payment-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/payment-summary/index.tsx
@@ -13,8 +13,23 @@ const PaymentSummary = async ({ cartId }: { cartId: string }) => {
     if (!cart) {
         console.log('cart not found');
         return (
-            <Flex bgColor="#121212" color="white" maxW={{ base: '100%', md: '401px' }} width="100%" minHeight="400px" flexDir="column" borderRadius="16px" p={{ base: '16px', md: '40px' }} align="center" justify="center">
-                <Text color="primary.green.900" fontSize="18px" fontWeight={600}>
+            <Flex
+                bgColor="#121212"
+                color="white"
+                maxW={{ base: '100%', md: '401px' }}
+                width="100%"
+                minHeight="400px"
+                flexDir="column"
+                borderRadius="16px"
+                p={{ base: '16px', md: '40px' }}
+                align="center"
+                justify="center"
+            >
+                <Text
+                    color="primary.green.900"
+                    fontSize="18px"
+                    fontWeight={600}
+                >
                     Payment Summary
                 </Text>
                 <Text mt="2" fontSize="14px">
@@ -54,7 +69,7 @@ const PaymentSummary = async ({ cartId }: { cartId: string }) => {
 
             <CartTotals cartId={cartId} useCartStyle={true} />
 
-            <Flex mt="auto" flexDir={'column'} gap={5}>
+            <Flex mt="auto" flexDir={'column'} gap={2}>
                 <DiscountCode cartId={cartId} />
                 <PaymentButton cart={cart} />
                 {/* <Text

--- a/hamza-client/src/modules/common/components/cart-totals/index.tsx
+++ b/hamza-client/src/modules/common/components/cart-totals/index.tsx
@@ -6,7 +6,7 @@ import { formatCryptoPrice } from '@lib/util/get-product-price';
 import { convertPrice } from '@/lib/util/price-conversion';
 import React from 'react';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
-import { Flex, Text, Divider, Spinner } from '@chakra-ui/react';
+import { Flex, Text, Divider, Spinner, VStack } from '@chakra-ui/react';
 import currencyIcons from '../../../../../public/images/currencies/crypto-currencies';
 import { getCartShippingCost, updateShippingCost } from '@lib/server';
 import { useCartShippingOptions } from 'medusa-react';
@@ -83,6 +83,10 @@ const CartTotals: React.FC<CartTotalsProps> = ({ useCartStyle, cartId }) => {
         );
     };
 
+    const convertToBTC = (amount: number) => {
+        return amount / 100000000;
+    };
+
     const finalSubtotal = getCartSubtotal(
         cart ?? null,
         preferred_currency_code ?? 'usdc',
@@ -93,6 +97,8 @@ const CartTotals: React.FC<CartTotalsProps> = ({ useCartStyle, cartId }) => {
         preferred_currency_code ?? 'usdc',
         { includeDiscounts: true }
     );
+    const convertBtcTotal = convertToBTC(finalTotal.amount ?? 0);
+
     const taxTotal = cart?.tax_total ?? 0;
     const grandTotal = (finalTotal.amount ?? 0) + shippingCost + taxTotal;
     const displayCurrency =
@@ -231,49 +237,57 @@ const CartTotals: React.FC<CartTotalsProps> = ({ useCartStyle, cartId }) => {
                     {loading ? (
                         <Spinner size="sm" color="white" />
                     ) : (
-                        <Flex flexDirection="column" alignItems="flex-end">
-                            <Flex flexDirection={'row'} alignItems="center">
-                                <Flex alignItems={'center'}>
-                                    <Image
-                                        className="h-[14px] w-[14px] md:h-[20px] md:w-[20px]"
-                                        src={currencyIcons[displayCurrency]}
-                                        alt={displayCurrency}
-                                    />
-                                </Flex>
-                                <Text
-                                    ml={{ base: '0.4rem', md: '0.5rem' }}
-                                    fontSize={{ base: '15px', md: '24px' }}
-                                    fontWeight={700}
-                                    lineHeight="1.1"
-                                    position="relative"
-                                    top="1px"
-                                    className="cart-totals-total"
-                                >
-                                    {formatCryptoPrice(
-                                        grandTotal,
-                                        displayCurrency
-                                    )}
-                                </Text>
-                            </Flex>
-                            {preferred_currency_code === 'eth' && (
-                                <Flex justifyContent="flex-end" width="100%">
+                        <VStack alignItems="flex-end">
+                            <Flex flexDirection="column" alignItems="flex-end">
+                                <Flex flexDirection={'row'} alignItems="center">
+                                    <Flex alignItems={'center'}>
+                                        <Image
+                                            className="h-[14px] w-[14px] md:h-[20px] md:w-[20px]"
+                                            src={currencyIcons[displayCurrency]}
+                                            alt={displayCurrency}
+                                        />
+                                    </Flex>
                                     <Text
-                                        as="h3"
-                                        variant="semibold"
-                                        color="white"
-                                        mt={2}
-                                        fontSize={{
-                                            base: '15px',
-                                            md: '18px',
-                                        }}
+                                        ml={{ base: '0.4rem', md: '0.5rem' }}
+                                        fontSize={{ base: '15px', md: '24px' }}
                                         fontWeight={700}
-                                        textAlign="right"
+                                        lineHeight="1.1"
+                                        position="relative"
+                                        top="1px"
+                                        className="cart-totals-total"
                                     >
-                                        {`≅ $${convertedPrice} USD`}
+                                        {formatCryptoPrice(
+                                            grandTotal,
+                                            displayCurrency
+                                        )}
                                     </Text>
                                 </Flex>
-                            )}
-                        </Flex>
+                                {preferred_currency_code === 'eth' && (
+                                    <Flex
+                                        justifyContent="flex-end"
+                                        width="100%"
+                                    >
+                                        <Text
+                                            as="h3"
+                                            variant="semibold"
+                                            color="white"
+                                            mt={2}
+                                            fontSize={{
+                                                base: '15px',
+                                                md: '18px',
+                                            }}
+                                            fontWeight={700}
+                                            textAlign="right"
+                                        >
+                                            {`≅ $${convertedPrice} USD`}
+                                        </Text>
+                                    </Flex>
+                                )}
+                            </Flex>
+                            <Flex>
+                                <Text>≅ {convertBtcTotal} BTC</Text>
+                            </Flex>
+                        </VStack>
                     )}
                 </Flex>
             )}

--- a/hamza-client/src/modules/common/components/modal-cover-wallet-connect/index.tsx
+++ b/hamza-client/src/modules/common/components/modal-cover-wallet-connect/index.tsx
@@ -2,67 +2,90 @@ import { Button, Box, Flex, Text } from '@chakra-ui/react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import Loading from '@/app/[countryCode]/(main)/account/loading';
 
-export const ModalCoverWalletConnect = ({ title, message, pageIsLoading }: { title: string, message: string, pageIsLoading: boolean }) => {
-	return (
-			<Box
-					position="fixed"
-					top="0"
-					left="0"
-					width="100vw"
-					height="100vh"
-					zIndex="9999"
-					display="flex"
-					justifyContent="center"
-					alignItems="center"
-					backgroundColor="#040404"
-					color={'white'}
-					flexDirection={'column'}
-			>
-					<Flex
-							flexDir={'column'}
-							justifyContent={'center'}
-							alignItems={'center'}
-							borderRadius={'12px'}
-							gap={5}
-							backgroundColor={'#121212'}
-							height={'400px'}
-							width={'500px'}
-					>
-							<Text
-									color={'white'}
-									fontSize={'24px'}
-							>
-									{title}
-									{!title && "Wallet Connection"}
-							</Text>
-							<Text
-									color={'white'}
-									textAlign={'center'}
-							>
-									{message}
-									{!message && "Please connect your wallet to continue."}
-							</Text>
-							<ConnectButton.Custom>
-									{({ openConnectModal, authenticationStatus }) => {
-											if (authenticationStatus === 'unauthenticated' && pageIsLoading) {
-													return (
-															<Button
-																	borderRadius={'30px'}
-																	backgroundColor={'primary.green.900'}
-																	onClick={openConnectModal}
-																	ml="1rem"
-																	height="54px"
-																	fontSize={'20px'}
-															>
-																	Connect Wallet
-															</Button>
-													);
-											} else {
-													return <Loading style={{ padding: 0, margin: 0, height: '50px' }} />;
-											}
-									}}
-							</ConnectButton.Custom>
-					</Flex>
-			</Box>
-	);
+export const ModalCoverWalletConnect = ({
+    title,
+    message,
+    pageIsLoading,
+}: {
+    title: string;
+    message: string;
+    pageIsLoading: boolean;
+}) => {
+    return (
+        <Box
+            position="fixed"
+            top="0"
+            left="0"
+            width="100vw"
+            height="100vh"
+            zIndex="9999"
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            backgroundColor="#040404"
+            color={'white'}
+            flexDirection={'column'}
+            px={{ base: '1rem', md: 0 }}
+        >
+            <Flex
+                flexDir={'column'}
+                justifyContent={'center'}
+                alignItems={'center'}
+                borderRadius={'12px'}
+                gap={5}
+                backgroundColor={'#121212'}
+                height={{ base: 'auto', md: '400px' }}
+                width={{ base: '100%', md: '500px' }}
+                py={{ base: 8, md: 0 }}
+            >
+                <Text
+                    color={'white'}
+                    fontSize={{ base: '20px', md: '24px' }}
+                    textAlign="center"
+                    px={4}
+                >
+                    {title || 'Wallet Connection'}
+                </Text>
+                <Text
+                    color={'white'}
+                    textAlign={'center'}
+                    px={4}
+                    fontSize={{ base: '16px', md: 'inherit' }}
+                >
+                    {message || 'Please connect your wallet to continue.'}
+                </Text>
+                <ConnectButton.Custom>
+                    {({ openConnectModal, authenticationStatus }) => {
+                        if (
+                            authenticationStatus === 'unauthenticated' &&
+                            pageIsLoading
+                        ) {
+                            return (
+                                <Button
+                                    borderRadius={'30px'}
+                                    backgroundColor={'primary.green.900'}
+                                    onClick={openConnectModal}
+                                    height={{ base: '48px', md: '54px' }}
+                                    fontSize={{ base: '16px', md: '20px' }}
+                                    mx={4}
+                                >
+                                    Connect Wallet
+                                </Button>
+                            );
+                        } else {
+                            return (
+                                <Loading
+                                    style={{
+                                        padding: 0,
+                                        margin: 0,
+                                        height: '50px',
+                                    }}
+                                />
+                            );
+                        }
+                    }}
+                </ConnectButton.Custom>
+            </Flex>
+        </Box>
+    );
 };


### PR DESCRIPTION
BTC WIP

Checkout page:
- checkout has btc button, clicking will direct to payment processing page with qr code modal open
- btc fake calculated amount

Payment processing page:
- payment processing handles btc using paywith param (probably should come from payment object) 
- payment processing opens modal with openqrmodal param (think this should be ok in live)
- button to open btc modal if paywith is bitcoin

**TEST:**
- To view the payment process page - if async flow isn't set - with no order create yet - you'll need to have a completed checkout, then use the cart id of a previous order and visit:
http://localhost:8000/en/order/processing/[cart_id]?paywith=bitcoin&openqrmodal=true