### PR TITLE
HAMSTR-466: Payment Processing Page

### DIFF
--- a/hamza-client/src/app/[countryCode]/(main)/order/processing/[id]/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(main)/order/processing/[id]/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 type Props = {
     params: { id: string };
-    searchParams: { paywith?: string; openqrmodal?: string };
+    searchParams: { paywith?: string; openqrmodal?: string; checkout?: string };
 };
 
 interface BlockchainData {
@@ -96,6 +96,7 @@ export default async function ProcessingPage({ params, searchParams }: Props) {
         !searchParams.openqrmodal || searchParams.paywith !== 'bitcoin'
             ? 'false'
             : searchParams.openqrmodal;
+    const fromCheckout: boolean = searchParams.checkout == 'true';
 
     const paymentsData = await buildPaymentsData(cartId);
 
@@ -108,6 +109,7 @@ export default async function ProcessingPage({ params, searchParams }: Props) {
                 cartId={cartId}
                 paywith={paywith}
                 openqrmodal={openqrmodal}
+                fromCheckout={fromCheckout}
             />
         </Container>
     );

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -200,11 +200,14 @@ const CryptoPaymentButton = ({
      */
     const redirectToPaymentProcessing = (
         cartId: string,
-        countryCode: string
+        countryCode: string,
+        fromCheckout: boolean = false
     ) => {
         //finally, if all good, redirect to order confirmation page
         if (cartId?.length) {
-            router.push(`/${countryCode}/order/processing/${cartId}/`);
+            let url: string = `/${countryCode}/order/processing/${cartId}`;
+            if (fromCheckout) url += '?checkout=true';
+            router.push(url);
         }
     };
 
@@ -261,7 +264,7 @@ const CryptoPaymentButton = ({
                     //} else if (response.status == 200) {
                     if (data.checkout_mode === 'ASYNC') {
                         console.log('redirecting to payments page');
-                        redirectToPaymentProcessing(cart.id, countryCode);
+                        redirectToPaymentProcessing(cart.id, countryCode, true);
                     } else {
                         console.log('redirecting to confirmation page');
                         redirectToOrderConfirmation(

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/payment-handlers/async.ts
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/payment-handlers/async.ts
@@ -84,7 +84,7 @@ export class AsyncPaymentHandler implements IWalletPaymentHandler {
                     }
                 }
 
-                //wait for tx to be confirmed
+                //don't wait for tx to be confirmed
                 if (tx) {
                     transaction_id = tx.hash;
                 }

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -143,8 +143,10 @@ const OrderProcessing = ({
                             payment.status === COMPLETED_PAYMENT_STATUS &&
                             fromCheckout
                         ) {
+                            clearInterval(timer);
+
+                            //pause 3 seconds before redirecting
                             setTimeout(() => {
-                                clearInterval(timer);
                                 router.push(
                                     `/order/confirmed/${payment.orders[0].id}?cart=${cartId}`
                                 );

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -32,8 +32,6 @@ import { useAccount } from 'wagmi';
 import { ModalCoverWalletConnect } from '../common/components/modal-cover-wallet-connect';
 import { calculateStepState } from './utils';
 
-const COMPLETED_PAYMENT_STATUS = 'received';
-
 const OrderProcessing = ({
     startTimestamp,
     endTimestamp,
@@ -140,17 +138,17 @@ const OrderProcessing = ({
 
                         // Redirect if payment is in escrow
                         if (
-                            payment.status === COMPLETED_PAYMENT_STATUS &&
+                            (payment.status === 'received' ||
+                                payment.status === 'in_escrow') &&
                             fromCheckout
                         ) {
+                            //pause 2 seconds before redirecting
                             clearInterval(timer);
-
-                            //pause 3 seconds before redirecting
                             setTimeout(() => {
                                 router.push(
                                     `/order/confirmed/${payment.orders[0].id}?cart=${cartId}`
                                 );
-                            }, 3000);
+                            }, 2000);
                         }
                     }
                 } catch (error) {

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -32,6 +32,8 @@ import { useAccount } from 'wagmi';
 import { ModalCoverWalletConnect } from '../common/components/modal-cover-wallet-connect';
 import { calculateStepState } from './utils';
 
+const COMPLETED_PAYMENT_STATUS = 'received';
+
 const OrderProcessing = ({
     startTimestamp,
     endTimestamp,
@@ -137,7 +139,10 @@ const OrderProcessing = ({
                         }
 
                         // Redirect if payment is in escrow
-                        if (payment.status === 'in_escrow' && fromCheckout) {
+                        if (
+                            payment.status === COMPLETED_PAYMENT_STATUS &&
+                            fromCheckout
+                        ) {
                             setTimeout(() => {
                                 clearInterval(timer);
                                 router.push(


### PR DESCRIPTION
**Motivation**
Shortening the wait time, now we want to redirect to thankyou page (consider the payment to be 'complete' as far as the customer's concerned) as soon as it's received in the payment wallet; not waiting until it's in escrow. 

**Changes**

1. Redirects to checkout when status hits "Received", rather than "In Escrow" (as before)

2. To ensure that users can use this page outside of the checkout process, it now takes a "?checkout" querystring parameter. If true, it will redirect when the status reaches 'received'; otherwise, it will just stay on the page indefinitely.

3. The status refresh (status panels) weren't refreshing in reaction to actual real-time changes from the server, but were only showing the true payment status on first page load. 