### PR TITLE
HAMSTR-483 : Refactor Release Escrow: Frontend

### DIFF
--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -457,6 +457,14 @@ export async function updateOrderEscrowStatus(
     });
 }
 
+export async function getEscrowPaymentData(order_id: string) {
+    return getSecure('/custom/order/escrow', { order_id });
+ }
+ 
+ export async function releaseOrderEscrow(order_id: string) {
+    return putSecure('/custom/order/escrow', { order_id });
+ }
+
 export async function cancelOrder(order_id: string, cancel_reason: string) {
     return putSecure('/custom/order/cancel', { order_id, cancel_reason });
 }

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -277,7 +277,7 @@ const CryptoPaymentButton = ({
                     //} else if (response.status == 200) {
                     if (data.checkout_mode === 'ASYNC') {
                         const payWith: string = chainType;
-                        const showQr: boolean = true;
+                        const showQr: boolean = paymentMode === 'direct';
                         console.log('redirecting to payments page');
                         redirectToPaymentProcessing(
                             cart.id,

--- a/hamza-client/src/modules/order/components/escrow/release-escrow-dialog.tsx
+++ b/hamza-client/src/modules/order/components/escrow/release-escrow-dialog.tsx
@@ -7,7 +7,7 @@ import { PaymentDefinition } from '@/web3/contracts/escrow';
 import { Button, useDisclosure, useToast } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Order } from '@/web3/contracts/escrow';
-import { updateOrderEscrowStatus } from '@/lib/server';
+import { updateOrderEscrowStatus, releaseOrderEscrow } from '@/lib/server';
 import { FaExclamationTriangle, FaQuestionCircle } from 'react-icons/fa';
 import { EscrowStatus } from '@/lib/server/enums';
 import GeneralModal from '../../../common/components/modal-confirm';
@@ -41,8 +41,8 @@ export const ReleaseEscrowDialog = ({
         setIsLoading(true);
 
         try {
-            const releaseData = await releaseEscrowPayment(order, 'buyer');
-            console.log('Escrow released data: ', releaseData);
+            //Release the escrow payment
+            await releaseOrderEscrow(order.id);
 
             //get escrowPayment to see if escrow contract completely released
             const escrowPayment = await getEscrowPayment(order);

--- a/hamza-client/src/modules/order/templates/escrow.tsx
+++ b/hamza-client/src/modules/order/templates/escrow.tsx
@@ -3,33 +3,19 @@ import {
     Box,
     Flex,
     Text,
-    Modal,
-    ModalOverlay,
-    ModalContent,
-    ModalHeader,
-    ModalBody,
-    useDisclosure,
-    ModalCloseButton,
 } from '@chakra-ui/react';
 import { MdOutlineHandshake } from 'react-icons/md';
 import { OrderComponent } from '@/modules/order/components/order-overview/order-component';
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { ReleaseEscrowDialog } from '../components/escrow/release-escrow-dialog';
 import EscrowStatus from '../components/order-overview/escrow-status';
 import { Order, PaymentDefinition } from '@/web3/contracts/escrow';
-import { useAccount, useNetwork, useSwitchNetwork } from 'wagmi';
+import { useAccount } from 'wagmi';
 import { ModalCoverWalletConnect } from '@/modules/common/components/modal-cover-wallet-connect';
 import { Customer } from '@/app/[countryCode]/(main)/account/@dashboard/escrow/[id]/page';
-import { getEscrowPayment } from '@/lib/util/order-escrow';
 import { useQuery } from '@tanstack/react-query';
-import { getChainId } from '@/web3';
 import { getEscrowPaymentData } from '@/lib/server';
 
-// TODO: need to get the escrow address and chain id for releasing
-// TODO: user must connect the chain id that belongs to the order?
-// TODO: the escrow contract is queried to make sure that the specified order exists in escrow, that it hasn't yet been released, and that there is money to release
-// TODO: API call to release escrow
-// TODO: When escrow completes, api should be made to sync with the order table escrow_status
 export const Escrow = ({
     id,
     customer,
@@ -40,43 +26,7 @@ export const Escrow = ({
     order: Order | null;
 }) => {
     const { isConnected } = useAccount();
-    const { chain } = useNetwork();
     const [isClient, setIsClient] = useState<boolean>(false);
-    const [isCorrectNetwork, setIsCorrectNetwork] = useState<boolean>(false);
-    const [currentChainName, setCurrentChainName] = useState<string | null>(
-        null
-    );
-    const [paymentChainName, setPaymentChainName] = useState<string | null>(
-        null
-    );
-    const { isOpen, onOpen, onClose } = useDisclosure();
-    const {
-        chains,
-        isLoading: isLoadingSwitchNetwork,
-        switchNetwork,
-    } = useSwitchNetwork();
-
-    const handleSwitchNetwork = useCallback(
-        (chainId: number) => {
-            try {
-                if (switchNetwork) {
-                    onOpen();
-                    switchNetwork(chainId);
-                    setIsCorrectNetwork(true);
-                } else {
-                    setIsCorrectNetwork(false);
-                    console.error(
-                        'Network switching is not supported by the current provider.'
-                    );
-                }
-            } catch (error) {
-                console.error(error);
-                setIsCorrectNetwork(false);
-            }
-        },
-        [switchNetwork, setIsCorrectNetwork, onOpen]
-    );
-
     const startTimeRef = useRef(Date.now());
     
     const { data: escrowPayment, isLoading: isLoadingEscrowPayment, isFetching } = useQuery<
@@ -95,11 +45,7 @@ export const Escrow = ({
                 return null;
             }
         },
-        enabled:
-            !!order &&
-            !isLoadingSwitchNetwork &&
-            isConnected &&
-            isCorrectNetwork,
+        enabled: !!order && isConnected,
         refetchInterval: () => {
             const elapsed = Date.now() - startTimeRef.current;
             if (elapsed > 120000) {
@@ -109,108 +55,9 @@ export const Escrow = ({
         },
     });
 
-    // TODO: right now, when switching chain on the same page, the
-    // name saved for currentChain is chain that the user is originally on.
-    // but since the user is switching the intended name to be saved is the
-    // chain being switched to.  This is a problem.  Leave this for future
-    // as the system works, but the alert will simply say switching from
-    // sepolia to sepolia instead of telling the user that the system is
-    // auto switching them back to sepolia from ... opnet for example.
     useEffect(() => {
         setIsClient(true);
-
-        // chain was added to detect chain switching on the page
-        // itself.  As a result, I need to keep the chain name before
-        // switching occurs, so it can be used in the modal.
-        if (chain && !currentChainName) {
-            setCurrentChainName(chain.name || null);
-        }
-
-        (async () => {
-            const chainId = await getChainId();
-            const paymentChainId =
-                order?.payments[0]?.blockchain_data?.chain_id;
-
-            const currentChain = chains.find(
-                (chain) => Number(chain.id) === Number(chainId)
-            );
-            const paymentChain = chains.find(
-                (chain) => Number(chain.id) === Number(paymentChainId)
-            );
-
-            if (!isLoadingSwitchNetwork) {
-                if (!currentChainName) {
-                    setCurrentChainName(currentChain?.name || null);
-                }
-                if (!paymentChainName) {
-                    setPaymentChainName(paymentChain?.name || null);
-                }
-            }
-
-            if (paymentChainId && paymentChainId !== Number(chainId)) {
-                handleSwitchNetwork(paymentChainId);
-            } else {
-                setIsCorrectNetwork(true);
-            }
-        })();
-    }, [
-        order,
-        handleSwitchNetwork,
-        isLoadingSwitchNetwork,
-        chains,
-        chain,
-        currentChainName,
-        paymentChainName,
-    ]);
-
-    const NetworkSwitchModal = (
-        <Modal isCentered isOpen={isOpen} onClose={onClose}>
-            <ModalOverlay />
-            <ModalContent
-                bg="#121212"
-                p="40px"
-                borderRadius={'16px'}
-                justifyContent={'center'}
-                alignItems={'center'}
-                color="white"
-                gap={2}
-                maxW={'496px'}
-                width={'100%'}
-            >
-                <ModalCloseButton color="white" />
-                <ModalBody
-                    display="flex"
-                    justifyContent={'center'}
-                    alignItems={'center'}
-                    flexDir={'column'}
-                >
-                    <ModalHeader
-                        fontSize="24px"
-                        fontWeight="bold"
-                        textAlign={'center'}
-                    >
-                        Switching Network
-                    </ModalHeader>
-                    <Text
-                        fontSize="16px"
-                        maxW={'332px'}
-                        width={'100%'}
-                        textAlign={'center'}
-                    >
-                        Since your payment is on{' '}
-                        <strong className="text-[#94d42a]">
-                            [{paymentChainName}]
-                        </strong>{' '}
-                        and your wallet is on{' '}
-                        <strong className="text-[#94d42a]">
-                            [{currentChainName}]
-                        </strong>
-                        , we must switch networks to proceed.
-                    </Text>
-                </ModalBody>
-            </ModalContent>
-        </Modal>
-    );
+    }, []);
 
     if (!isClient) {
         return (
@@ -219,7 +66,7 @@ export const Escrow = ({
                 message="To view escrow details, please connect your wallet"
                 pageIsLoading={isClient}
             />
-        ); // Render nothing on the server
+        );
     }
 
     return (
@@ -237,7 +84,6 @@ export const Escrow = ({
             alignItems={'center'}
             backgroundColor={'#121212'}
         >
-            {NetworkSwitchModal}
             {!isConnected ? (
                 <ModalCoverWalletConnect
                     title="Proceed to Escrow"
@@ -270,7 +116,7 @@ export const Escrow = ({
                         </Text>
                     )}
 
-                    {/* Customer and Order problems */}
+                    {/* Display order details */}
                     {order && (
                         <>
                             {order.id}
@@ -281,7 +127,7 @@ export const Escrow = ({
                     {/* Escrow Payment Status */}
                     {order && (
                         <>
-                            {(isLoadingEscrowPayment || isLoadingSwitchNetwork) && !escrowPayment ? (
+                            {isLoadingEscrowPayment && !escrowPayment ? (
                                 <Flex direction="column" align="center" justify="center" my={4}>
                                     <Text mb={3}>Setting up escrow...</Text>
                                     <Text fontSize="sm" color="whiteAlpha.700">

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -366,7 +366,7 @@ const Processing = ({
                                                         >
                                                             Request Cancellation
                                                         </Button>
-                                                        {order.escrow_status &&
+                                                        {order.escrow_status !== 'buyer_released' &&
                                                             order.escrow_status !==
                                                                 'released' && (
                                                                 <Box


### PR DESCRIPTION
**Motivation**

Previously on MacGuyver, we have deployed an escrow contract to every chain that we support. Then, in order to release escrow, a customer simply connects their wallet (on the chain on which they had paid), connects to the escrow contract on that chain, and interacts with it directly to release the escrow. 

Now, we have to change that. The escrow will all be on $HOME chain, and there is no guarantee that the user has enough funds on that chain to interact with a contract on it. 


**Changes:**

1. Added backend API calls getEscrowPaymentData and releaseOrderEscrow
2. Updated escrow page to call releaseOrderEscrow when the "Release Escrow" button is clicked
3. Implemented polling with refetchInterval for escrow data to handle delays between payment and contract update

**Testing:**

**Configure environment:**

1. in hamza-backend .env 
     - Set CHECKOUT_MODE=ASYNC 
2. In payment-processor .env, 
     - set MOVE_PAYMENTS_TO_ESCROW=1 
     - VERIFY_TRANSACTIONS=1


**Test flow:**

1. Purchase a product
2. Send payment to the payment address from the order processing page
4. Wait for payment processor to verify and move funds to escrow
5. Click View escrow from the thank you page (may take a minute to appear)
6. Click "Release Escrow"


**Verify results:**

Check escrow data using the endpoint: 
`GET http://localhost:9000/custom/order/escrow?order_id=ORDER_ID`
Confirm that payerReleased and released change from false to true


**Note:** 

For testing call direct custom/order/escrow , you may need to comment out the customer ID enforcement check (if (!handler.enforceCustomerId(order.customer_id)) return false;) in the route to avoid authorization issues.