### PR TITLE
HAMSTR-517 cover not block bottom interaction

### DIFF
--- a/hamza-client/src/app/components/loaders/hamza-logo-loader.tsx
+++ b/hamza-client/src/app/components/loaders/hamza-logo-loader.tsx
@@ -3,7 +3,7 @@
 import { Box, Text } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
 import Image from 'next/image';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import HamzaLogoBlack from '../../../../public/images/logo/hamza-logo-black.svg'; // Ensure this is a transparent image
 
 // Define the keyframes for the smooth infinite gradient animation
@@ -94,11 +94,20 @@ const HamzaLogoLoader: React.FC<HamzaLogoLoaderProps> = ({
             alignItems="center"
             backgroundColor="#040404"
             flexDirection={'column'}
+            overflow="hidden"
+            css={{
+                touchAction: 'none',
+                userSelect: 'none',
+                pointerEvents: 'none',
+                '& > *': {
+                    pointerEvents: 'auto',
+                },
+            }}
         >
             <Box
                 position="relative"
-                width="100px"
-                height="100px"
+                width={{ base: '80px', md: '100px' }}
+                height={{ base: '80px', md: '100px' }}
                 overflow="hidden"
                 borderRadius="12px"
                 display="flex"

--- a/hamza-client/src/modules/checkout/templates/checkout-details/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/checkout-details/index.tsx
@@ -8,8 +8,6 @@ import {
     getHamzaCustomer,
     listShippingMethods,
 } from '@/lib/server';
-import { redirect } from 'next/navigation';
-import { SwitchNetwork } from '@/app/components/providers/rainbowkit/rainbowkit-utils/rainbow-utils';
 
 export default async function CheckoutDetails({
     cart,

--- a/hamza-client/src/modules/checkout/templates/order-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/order-summary/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, Text, Spinner } from '@chakra-ui/react';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
 import React from 'react';
 import ForceWalletConnect from '@modules/common/components/force-wallet-connect';
@@ -8,8 +8,9 @@ import { CartWithCheckoutStep } from '@/types/global';
 import { organizeCartItemsByStore } from '@/app/[countryCode]/(main)/cart/utils/fetch-cart-for-cart';
 import EmptyCart from '@/modules/cart/components/empty-cart';
 import StoreItems from '@/modules/cart/components/store-items';
-
+import { useCartStore } from '@/zustand/cart-store/cart-store';
 const OrderSummary = ({ cart }: { cart: CartWithCheckoutStep }) => {
+    const { isProcessingOrder } = useCartStore();
     const { preferred_currency_code } = useCustomerAuthStore();
 
     // State to control delay for showing ForceWalletConnect
@@ -20,6 +21,10 @@ const OrderSummary = ({ cart }: { cart: CartWithCheckoutStep }) => {
     }
 
     const stores = organizeCartItemsByStore(cart as CartWithCheckoutStep);
+
+    if (isProcessingOrder) {
+        return <Spinner />;
+    }
 
     return (
         <Flex

--- a/hamza-client/src/zustand/cart-store/cart-store.ts
+++ b/hamza-client/src/zustand/cart-store/cart-store.ts
@@ -2,13 +2,18 @@ import { create } from 'zustand';
 
 type State = {
     isUpdatingCart: boolean;
+    isProcessingOrder: boolean;
 };
 
 type Action = {
     setIsUpdatingCart: (updating: boolean) => void;
+    setIsProcessingOrder: (processing: boolean) => void;
 };
 
 export const useCartStore = create<State & Action>((set) => ({
     isUpdatingCart: false,
+    isProcessingOrder: false,
     setIsUpdatingCart: (updating: boolean) => set({ isUpdatingCart: updating }),
+    setIsProcessingOrder: (processing: boolean) =>
+        set({ isProcessingOrder: processing }),
 }));


### PR DESCRIPTION
Problem:
This allowed me to manipulate the checkout process by hijacking the cover (control hide/show behavior - weak):
- I was basically able to checkout 1 item
- During processing, I was able to change the quantity of my order
- When order complete, the amount charged was for 1 item, but the final order in database was for 30 items.

Solution:
During order processing, product management in checkout page is hidden from display, preventing interaction.  

**TEST:**
1. When checking out, with metamask open, go back to webpage and see if you can manipulate the page with "Processing Order..." - you can try using css to hide the cover to see what you can manipulate.
