### PR TITLE
HAMSTR-518: Payment # on Payment Processing Page

### DIFF
--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -149,7 +149,7 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                     fontWeight="500"
                     display={{ base: 'none', md: 'block' }}
                 >
-                    Payment #{orders[0].cart?.id}
+                    Cart ID: {orders[0].cart?.id}
                 </Text>
                 <Text
                     fontSize="18px"

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -243,7 +243,11 @@ const OrderProcessing = ({
                                 </Box>
                             </HStack>
 
-                            <Text color="gray.300">Payment #{cartId}</Text>
+                            <Text color="gray.300">Cart ID: {cartId}</Text>
+                            <Text color="gray.300">
+                                Payment ID:{' '}
+                                {initialPaymentData?.paymentAddress ?? ''}
+                            </Text>
 
                             {/* Status Steps */}
                             <Box display={{ base: 'block', md: 'none' }}>

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -244,10 +244,6 @@ const OrderProcessing = ({
                             </HStack>
 
                             <Text color="gray.300">Cart ID: {cartId}</Text>
-                            <Text color="gray.300">
-                                Payment ID:{' '}
-                                {initialPaymentData?.paymentAddress ?? ''}
-                            </Text>
 
                             {/* Status Steps */}
                             <Box display={{ base: 'block', md: 'none' }}>


### PR DESCRIPTION
**Motivation**
The cart ID is actually useful to have there, but we should just label it as what it is. The Payment address is already on the page, so doesn't need to be listed twice.

**Changes**
Just changed the label of "Payment #" to "Cart ID"