### PR TITLE
HAMSTR-516 : On Mobile, Currency Selector not Working as Expected

### DIFF
--- a/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/wallet-info-menu-mobile.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/wallet-info-menu-mobile.tsx
@@ -11,6 +11,7 @@ import {
     MenuList,
 } from '@chakra-ui/react';
 import { useAccount, useBalance, useNetwork } from 'wagmi';
+import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth'; // Import Zustand store
 
 import { getCurrencyAddress } from '@/currency.config';
 import AddressDisplay from '../components/address-display';
@@ -29,13 +30,21 @@ interface NewWalletInfoProps {
 const WalletInfoMobile: React.FC<NewWalletInfoProps> = ({
     chainName,
     chain,
-    preferred_currency_code,
+    preferred_currency_code: initialPreferredCurrencyCode,
 }) => {
     const { address } = useAccount();
     const { chain: networkChain } = useNetwork();
     const chainId = networkChain?.id ?? 1;
+
+    // Fetch preferredCurrency from Zustand store
+    const preferred_currency_code = useCustomerAuthStore(
+        (state) => state.preferred_currency_code
+    );
+
+    const effectivePreferredCurrencyCode = preferred_currency_code || initialPreferredCurrencyCode;
+
     const [selectedCurrency, setSelectedCurrency] = useState(
-        preferred_currency_code ?? 'eth'
+        effectivePreferredCurrencyCode ?? 'eth'
     );
 
     // Query native ETH balance
@@ -173,7 +182,7 @@ const WalletInfoMobile: React.FC<NewWalletInfoProps> = ({
 
                             <CurrencySelector
                                 isOpen={isOpen}
-                                preferredCurrencyCode={preferred_currency_code}
+                                preferredCurrencyCode={effectivePreferredCurrencyCode}
                                 defaultCurrency="eth"
                                 selectedCurrency={selectedCurrency}
                                 setSelectedCurrency={setSelectedCurrency}


### PR DESCRIPTION
Changes:

1. Imported Zustand store (useCustomerAuthStore) in WalletInfoMobile to dynamically fetch preferred_currency_code from the store, ensuring selectedCurrency initializes correctly.
2. Updated WalletInfoMobile to use effectivePreferredCurrencyCode (combining the store value and prop fallback) to prevent selectedCurrency from resetting to ETH on re-render.
3. Updated the preferredCurrencyCode prop in CurrencySelector to use effectivePreferredCurrencyCode instead of the raw prop.


Test Steps (Mobile):

1. In the Hamza-Medusa file rainbow-provider.tsx, update const MEDUSA_SERVER_URL to {pc_ip_address}:9000.
2. In the Hamza-Backend file middlewares.ts, update const STORE_CORS to {pc_ip_address}:8000.
3. On a mobile device connected to the same network as the desktop, open Chrome and log in with MetaMask.
4. Open the currency selector, select USDT, close it, and reopen it to confirm that it retains USDT (does not reset to ETH).

Test Steps (Desktop) 

1. Open Chrome DevTools, toggle the device toolbar, and resize the viewport to a mobile view to test the mobile layout.
2. Open the currency selector, select USDT, close it, and reopen it to confirm that it retains USDT (does not reset to ETH).
