### PR TITLE
HAMSTR-515 - hide shipping cost when zero

### DIFF
--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -354,32 +354,34 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                     </Text>
                                 </HStack>
                                 <VStack align="flex-end">
-                                    <HStack>
-                                        <Text color="gray.500">
-                                            Shipping Cost:
-                                        </Text>
-                                        <Flex>
-                                            <Image
-                                                className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                                src={
-                                                    currencyIcons[
-                                                        order.currency_code ??
-                                                            'usdc'
-                                                    ]
-                                                }
-                                                alt={
-                                                    order.currency_code ??
-                                                    'usdc'
-                                                }
-                                            />
-                                            <Text ml="0.4rem" color="white">
-                                                {formatCryptoPrice(
-                                                    orderShippingTotal,
-                                                    order.currency_code
-                                                )}
+                                    {orderShippingTotal > 0 && (
+                                        <HStack>
+                                            <Text color="gray.500">
+                                                Shipping Cost:
                                             </Text>
-                                        </Flex>
-                                    </HStack>
+                                            <Flex>
+                                                <Image
+                                                    className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
+                                                    src={
+                                                        currencyIcons[
+                                                            order.currency_code ??
+                                                                'usdc'
+                                                        ]
+                                                    }
+                                                    alt={
+                                                        order.currency_code ??
+                                                        'usdc'
+                                                    }
+                                                />
+                                                <Text ml="0.4rem" color="white">
+                                                    {formatCryptoPrice(
+                                                        orderShippingTotal,
+                                                        order.currency_code
+                                                    )}
+                                                </Text>
+                                            </Flex>
+                                        </HStack>
+                                    )}
                                     {orderDiscountTotal > 0 && (
                                         <HStack>
                                             <Text color="gray.500">
@@ -437,22 +439,24 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                             </Text>
                         </HStack>
                     </Flex>
-                    <Flex justify="space-between" color="gray.300">
-                        <Text>Total Shipping Cost:</Text>
-                        <HStack>
-                            <Image
-                                className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                src={currencyIcons[currencyCode ?? 'usdc']}
-                                alt={currencyCode ?? 'usdc'}
-                            />
-                            <Text>
-                                {formatCryptoPrice(
-                                    cartShippingTotal,
-                                    currencyCode
-                                )}
-                            </Text>
-                        </HStack>
-                    </Flex>
+                    {cartShippingTotal > 0 && (
+                        <Flex justify="space-between" color="gray.300">
+                            <Text>Total Shipping Cost:</Text>
+                            <HStack>
+                                <Image
+                                    className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
+                                    src={currencyIcons[currencyCode ?? 'usdc']}
+                                    alt={currencyCode ?? 'usdc'}
+                                />
+                                <Text>
+                                    {formatCryptoPrice(
+                                        cartShippingTotal,
+                                        currencyCode
+                                    )}
+                                </Text>
+                            </HStack>
+                        </Flex>
+                    )}
                     {/* <Flex justify="space-between" color="gray.300">
                         <Text>Taxes:</Text>
                         <Text>


### PR DESCRIPTION
**Problem:**
When shipping cost is zero for an order, or the entire cart, the shipping cost should remain hidden.

**TEST:**
1. Add to cart with products that belong to store with no shipping cost (you can manipulate the store_ship_spec table), as that defines the shipping cost per store
2. Add to cart products that have shipping cost
3. Checkout and reach order confirmation page
4. Make sure store with no shipping cost have hidden ship cost