### PR TITLE
HAMSTR-560: payment chain vs. escrow chain

### DIFF
--- a/hamza-client/src/modules/order/templates/cancelled.tsx
+++ b/hamza-client/src/modules/order/templates/cancelled.tsx
@@ -14,30 +14,30 @@ import {
 } from '@chakra-ui/react';
 import CancelCard from '@modules/account/components/cancel-card';
 import EmptyState from '@modules/order/components/empty-state';
-import {useQueryClient} from '@tanstack/react-query';
-import React, {useState} from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import React, { useState } from 'react';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
 import CancellationModal from '@modules/order/templates/cancelled-modal';
-import {OrdersData} from './all';
-import {useOrderTabStore} from '@/zustand/order-tab-state';
+import { OrdersData } from './all';
+import { useOrderTabStore } from '@/zustand/order-tab-state';
 import OrderTimeline from '@modules/order/components/order-timeline';
-import {formatCryptoPrice} from '@lib/util/get-product-price';
-import {upperCase} from 'lodash';
+import { formatCryptoPrice } from '@lib/util/get-product-price';
+import { upperCase } from 'lodash';
 import {
     chainIdToName,
     getChainLogo,
 } from '@modules/order/components/chain-enum/chain-enum';
 import Image from 'next/image';
-import {OrderNote} from './all'
+import { OrderNote } from './all';
 import { format } from 'date-fns';
 
 const Cancelled = ({
-                       customer,
-                       // chainEnabled,
-                       // onSuccess,
-                       isEmpty,
-                   }: {
+    customer,
+    // chainEnabled,
+    // onSuccess,
+    isEmpty,
+}: {
     customer: string;
     // chainEnabled?: boolean;
     // onSuccess?: () => void;
@@ -64,11 +64,11 @@ const Cancelled = ({
 
     const canceledOrder = cachedData?.Cancelled || [];
     if (isEmpty && canceledOrder && canceledOrder?.length == 0) {
-        return <EmptyState/>;
+        return <EmptyState />;
     }
 
     return (
-        <div style={{width: '100%'}}>
+        <div style={{ width: '100%' }}>
             {/*{cancelIsLoading ? (*/}
             {/*    <Box*/}
             {/*        display="flex"*/}
@@ -107,7 +107,11 @@ const Cancelled = ({
                         );
 
                         // Check if we Seller has left a `PUBLIC` note, we're only returning public notes to client.
-                        const hasSellerNotes = order?.notes?.length > 0
+                        const hasSellerNotes = order?.notes?.length > 0;
+                        const chainId =
+                            order?.payments[0]?.blockchain_data
+                                ?.payment_chain_id ??
+                            order?.payments[0]?.blockchain_data?.chain_id;
 
                         return (
                             <Flex
@@ -190,7 +194,7 @@ const Cancelled = ({
                                                             'flex-end'
                                                         }
                                                         gap={2}
-                                                        mt={{base: 4, md: 0}}
+                                                        mt={{ base: 4, md: 0 }}
                                                         width="100%"
                                                     >
                                                         <Button
@@ -269,7 +273,7 @@ const Cancelled = ({
                                                         </a>
                                                         {order.escrow_status &&
                                                             order.escrow_status !==
-                                                            'released' && (
+                                                                'released' && (
                                                                 <Box
                                                                     as="a"
                                                                     href={`/account/escrow/${order.id}`}
@@ -300,7 +304,6 @@ const Cancelled = ({
                                                 <Box mt={4}>
                                                     <Tabs variant="unstyled">
                                                         <TabList>
-
                                                             <Tab
                                                                 _selected={{
                                                                     color: 'primary.green.900',
@@ -324,7 +327,7 @@ const Cancelled = ({
                                                                 Order Timeline
                                                             </Tab>
 
-                                                            {hasSellerNotes &&
+                                                            {hasSellerNotes && (
                                                                 <Tab
                                                                     _selected={{
                                                                         color: 'primary.green.900',
@@ -333,7 +336,10 @@ const Cancelled = ({
                                                                         borderColor:
                                                                             'primary.green.900',
                                                                     }}
-                                                                >Seller Note</Tab>}
+                                                                >
+                                                                    Seller Note
+                                                                </Tab>
+                                                            )}
                                                         </TabList>
                                                         <TabPanels>
                                                             <TabPanel>
@@ -362,8 +368,14 @@ const Cancelled = ({
                                                                         >
                                                                             {order.tracking_number && (
                                                                                 <>
-                                                                                    <Text><b>Tracking
-                                                                                        Number:</b> {order.tracking_number}
+                                                                                    <Text>
+                                                                                        <b>
+                                                                                            Tracking
+                                                                                            Number:
+                                                                                        </b>{' '}
+                                                                                        {
+                                                                                            order.tracking_number
+                                                                                        }
                                                                                     </Text>
                                                                                 </>
                                                                             )}
@@ -383,7 +395,7 @@ const Cancelled = ({
                                                                                                 ?.price
                                                                                         ),
                                                                                         item.currency_code ??
-                                                                                        'usdc'
+                                                                                            'usdc'
                                                                                     )}{' '}
                                                                                     {upperCase(
                                                                                         item.currency_code
@@ -425,11 +437,11 @@ const Cancelled = ({
                                                                                     </strong>{' '}
                                                                                     {order?.id &&
                                                                                     typeof order.id ===
-                                                                                    'string'
+                                                                                        'string'
                                                                                         ? order.id.replace(
-                                                                                            /^order_/,
-                                                                                            ''
-                                                                                        ) // Remove "order_" prefix
+                                                                                              /^order_/,
+                                                                                              ''
+                                                                                          ) // Remove "order_" prefix
                                                                                         : 'Order ID not available'}
                                                                                 </Text>
                                                                             </Flex>
@@ -446,16 +458,10 @@ const Cancelled = ({
                                                                                 </strong>
                                                                                 <Image
                                                                                     src={getChainLogo(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     alt={chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     width={
                                                                                         25
@@ -466,10 +472,7 @@ const Cancelled = ({
                                                                                 />
                                                                                 <Text>
                                                                                     {chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                 </Text>
                                                                             </Flex>
@@ -495,22 +498,55 @@ const Cancelled = ({
                                                                         boxShadow="sm"
                                                                         fontFamily="Inter, sans-serif"
                                                                     >
-                                                                        {order.notes.map((note: OrderNote, index: number) => (
-                                                                            <div key={note.id}>
-                                                                                {/* Date in smaller, gray text */}
-                                                                                <Text color="gray.400" fontSize="sm" mb={2}>
-                                                                                    {format(new Date(note.updated_at), 'EEEE, MMMM d, yyyy | h:mm a')}
-                                                                                </Text>
+                                                                        {order.notes.map(
+                                                                            (
+                                                                                note: OrderNote,
+                                                                                index: number
+                                                                            ) => (
+                                                                                <div
+                                                                                    key={
+                                                                                        note.id
+                                                                                    }
+                                                                                >
+                                                                                    {/* Date in smaller, gray text */}
+                                                                                    <Text
+                                                                                        color="gray.400"
+                                                                                        fontSize="sm"
+                                                                                        mb={
+                                                                                            2
+                                                                                        }
+                                                                                    >
+                                                                                        {format(
+                                                                                            new Date(
+                                                                                                note.updated_at
+                                                                                            ),
+                                                                                            'EEEE, MMMM d, yyyy | h:mm a'
+                                                                                        )}
+                                                                                    </Text>
 
-                                                                                {/* The note content */}
-                                                                                <Text color="white">{note.note}</Text>
+                                                                                    {/* The note content */}
+                                                                                    <Text color="white">
+                                                                                        {
+                                                                                            note.note
+                                                                                        }
+                                                                                    </Text>
 
-                                                                                {/* Divider between notes (except after the last one) */}
-                                                                                {index < order.notes.length - 1 && (
-                                                                                    <Divider my={4} borderColor="#272727" />
-                                                                                )}
-                                                                            </div>
-                                                                        ))}
+                                                                                    {/* Divider between notes (except after the last one) */}
+                                                                                    {index <
+                                                                                        order
+                                                                                            .notes
+                                                                                            .length -
+                                                                                            1 && (
+                                                                                        <Divider
+                                                                                            my={
+                                                                                                4
+                                                                                            }
+                                                                                            borderColor="#272727"
+                                                                                        />
+                                                                                    )}
+                                                                                </div>
+                                                                            )
+                                                                        )}
                                                                     </Box>
                                                                 </TabPanel>
                                                             )}

--- a/hamza-client/src/modules/order/templates/delivered.tsx
+++ b/hamza-client/src/modules/order/templates/delivered.tsx
@@ -13,30 +13,33 @@ import {
     VStack,
 } from '@chakra-ui/react';
 import Spinner from '@modules/common/icons/spinner';
-import {addToCart} from '@modules/cart/actions';
+import { addToCart } from '@modules/cart/actions';
 import toast from 'react-hot-toast';
 import DeliveredCard from '@modules/account/components/delivered-card';
 import EmptyState from '@modules/order/components/empty-state';
-import {useQuery, useQueryClient} from '@tanstack/react-query';
-import React, {useEffect, useState} from 'react';
-import {useParams, useRouter} from 'next/navigation';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import React, { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
-import {OrdersData} from './all';
-import {useOrderTabStore} from '@/zustand/order-tab-state';
+import { OrdersData } from './all';
+import { useOrderTabStore } from '@/zustand/order-tab-state';
 import Link from 'next/link';
 import OrderTimeline from '@modules/order/components/order-timeline';
-import {formatCryptoPrice} from '@lib/util/get-product-price';
-import {upperCase} from 'lodash';
-import {chainIdToName, getChainLogo} from '@modules/order/components/chain-enum/chain-enum';
+import { formatCryptoPrice } from '@lib/util/get-product-price';
+import { upperCase } from 'lodash';
+import {
+    chainIdToName,
+    getChainLogo,
+} from '@modules/order/components/chain-enum/chain-enum';
 import Image from 'next/image';
-import {OrderNote} from './all'
+import { OrderNote } from './all';
 import { format } from 'date-fns';
 
 const Delivered = ({
-                       customer,
-                       isEmpty,
-                   }: {
+    customer,
+    isEmpty,
+}: {
     customer: string;
     isEmpty?: boolean;
 }) => {
@@ -92,11 +95,11 @@ const Delivered = ({
     // }, [isStale]);
 
     if (isEmpty && deliveredOrder && deliveredOrder?.length == 0) {
-        return <EmptyState/>;
+        return <EmptyState />;
     }
 
     return (
-        <div style={{width: '100%'}}>
+        <div style={{ width: '100%' }}>
             {deliveredOrder && deliveredOrder.length > 0 ? (
                 <Flex width={'100%'} flexDirection="column">
                     {deliveredOrder.map((order: any) => {
@@ -107,7 +110,11 @@ const Delivered = ({
                         );
 
                         // Check if we Seller has left a `PUBLIC` note, we're only returning public notes to client.
-                        const hasSellerNotes = order?.notes?.length > 0
+                        const hasSellerNotes = order?.notes?.length > 0;
+                        const chainId =
+                            order?.payments[0]?.blockchain_data
+                                ?.payment_chain_id ??
+                            order?.payments[0]?.blockchain_data?.chain_id;
 
                         return (
                             <Flex
@@ -170,7 +177,7 @@ const Delivered = ({
                                                         md: 'row',
                                                     }}
                                                     justifyContent={'flex-end'}
-                                                    mt={{base: 4, md: 0}}
+                                                    mt={{ base: 4, md: 0 }}
                                                     width="100%"
                                                 >
                                                     {index ===
@@ -259,25 +266,29 @@ const Delivered = ({
                                                             Return/Refund
                                                         </Button>
                                                     </Link>
-                                                    {order.escrow_status && order.escrow_status !== 'released' && (
-                                                        <Box
-                                                            as="a"
-                                                            href={`/account/escrow/${order.id}`}
-                                                            border="1px solid"
-                                                            borderColor="white"
-                                                            borderRadius="37px"
-                                                            color="white"
-                                                            px="4"
-                                                            py="2"
-                                                            textAlign="center"
-                                                            _hover={{
-                                                                textDecoration: 'none',
-                                                                bg: 'primary.teal.600', // Adjust the hover color as needed
-                                                            }}
-                                                        >
-                                                            View Escrow Details
-                                                        </Box>
-                                                    )}
+                                                    {order.escrow_status &&
+                                                        order.escrow_status !==
+                                                            'released' && (
+                                                            <Box
+                                                                as="a"
+                                                                href={`/account/escrow/${order.id}`}
+                                                                border="1px solid"
+                                                                borderColor="white"
+                                                                borderRadius="37px"
+                                                                color="white"
+                                                                px="4"
+                                                                py="2"
+                                                                textAlign="center"
+                                                                _hover={{
+                                                                    textDecoration:
+                                                                        'none',
+                                                                    bg: 'primary.teal.600', // Adjust the hover color as needed
+                                                                }}
+                                                            >
+                                                                View Escrow
+                                                                Details
+                                                            </Box>
+                                                        )}
                                                 </Flex>
                                             </Flex>
                                             <Collapse
@@ -287,7 +298,6 @@ const Delivered = ({
                                                 <Box mt={4}>
                                                     <Tabs variant="unstyled">
                                                         <TabList>
-
                                                             <Tab
                                                                 _selected={{
                                                                     color: 'primary.green.900',
@@ -310,7 +320,7 @@ const Delivered = ({
                                                             >
                                                                 Order Timeline
                                                             </Tab>
-                                                            {hasSellerNotes &&
+                                                            {hasSellerNotes && (
                                                                 <Tab
                                                                     _selected={{
                                                                         color: 'primary.green.900',
@@ -319,10 +329,12 @@ const Delivered = ({
                                                                         borderColor:
                                                                             'primary.green.900',
                                                                     }}
-                                                                >Seller Note</Tab>}
+                                                                >
+                                                                    Seller Note
+                                                                </Tab>
+                                                            )}
                                                         </TabList>
                                                         <TabPanels>
-
                                                             <TabPanel>
                                                                 <VStack
                                                                     align="start"
@@ -331,46 +343,117 @@ const Delivered = ({
                                                                     borderRadius="lg"
                                                                     w="100%"
                                                                 >
-                                                                    <Flex direction={{base: "column", md: "row"}}
-                                                                          gap={6} w="100%">
+                                                                    <Flex
+                                                                        direction={{
+                                                                            base: 'column',
+                                                                            md: 'row',
+                                                                        }}
+                                                                        gap={6}
+                                                                        w="100%"
+                                                                    >
                                                                         {/* Left Column: Shipping Cost & Subtotal */}
-                                                                        <VStack align="start" spacing={2} flex="1">
-                                                                            {order?.shipping_methods[0]?.price && (
+                                                                        <VStack
+                                                                            align="start"
+                                                                            spacing={
+                                                                                2
+                                                                            }
+                                                                            flex="1"
+                                                                        >
+                                                                            {order
+                                                                                ?.shipping_methods[0]
+                                                                                ?.price && (
                                                                                 <Text fontSize="md">
-                                                                                    <strong>Order Shipping
-                                                                                        Cost:</strong>{' '}
-                                                                                    {formatCryptoPrice(Number(order?.shipping_methods[0]?.price), item.currency_code ?? 'usdc')}{' '}
-                                                                                    {upperCase(item.currency_code)}
+                                                                                    <strong>
+                                                                                        Order
+                                                                                        Shipping
+                                                                                        Cost:
+                                                                                    </strong>{' '}
+                                                                                    {formatCryptoPrice(
+                                                                                        Number(
+                                                                                            order
+                                                                                                ?.shipping_methods[0]
+                                                                                                ?.price
+                                                                                        ),
+                                                                                        item.currency_code ??
+                                                                                            'usdc'
+                                                                                    )}{' '}
+                                                                                    {upperCase(
+                                                                                        item.currency_code
+                                                                                    )}
                                                                                 </Text>
                                                                             )}
                                                                             <Text fontSize="md">
-                                                                                <strong>Subtotal:</strong>{' '}
-                                                                                {formatCryptoPrice(subTotal, item.currency_code)}{' '}
-                                                                                {upperCase(item.currency_code)}
+                                                                                <strong>
+                                                                                    Subtotal:
+                                                                                </strong>{' '}
+                                                                                {formatCryptoPrice(
+                                                                                    subTotal,
+                                                                                    item.currency_code
+                                                                                )}{' '}
+                                                                                {upperCase(
+                                                                                    item.currency_code
+                                                                                )}
                                                                             </Text>
                                                                         </VStack>
 
                                                                         {/* Right Column: Order ID & Chain Data */}
-                                                                        <VStack align="start" spacing={2} flex="1">
-                                                                            <Flex align="center" gap={2}>
+                                                                        <VStack
+                                                                            align="start"
+                                                                            spacing={
+                                                                                2
+                                                                            }
+                                                                            flex="1"
+                                                                        >
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
                                                                                 <Text fontSize="md">
-                                                                                    <strong>Order ID:</strong>{' '}
-                                                                                    {order?.id && typeof order.id === 'string'
-                                                                                        ? order.id.replace(/^order_/, '') // Remove "order_" prefix
+                                                                                    <strong>
+                                                                                        Order
+                                                                                        ID:
+                                                                                    </strong>{' '}
+                                                                                    {order?.id &&
+                                                                                    typeof order.id ===
+                                                                                        'string'
+                                                                                        ? order.id.replace(
+                                                                                              /^order_/,
+                                                                                              ''
+                                                                                          ) // Remove "order_" prefix
                                                                                         : 'Order ID not available'}
                                                                                 </Text>
                                                                             </Flex>
 
-                                                                            <Flex align="center" gap={2}>
-                                                                                <strong>Order Chain:</strong>
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <strong>
+                                                                                    Order
+                                                                                    Chain:
+                                                                                </strong>
                                                                                 <Image
-                                                                                    src={getChainLogo(order?.payments[0]?.blockchain_data?.chain_id)}
-                                                                                    alt={chainIdToName(order?.payments[0]?.blockchain_data?.chain_id)}
-                                                                                    width={25}
-                                                                                    height={25}
+                                                                                    src={getChainLogo(
+                                                                                        chainId
+                                                                                    )}
+                                                                                    alt={chainIdToName(
+                                                                                        chainId
+                                                                                    )}
+                                                                                    width={
+                                                                                        25
+                                                                                    }
+                                                                                    height={
+                                                                                        25
+                                                                                    }
                                                                                 />
                                                                                 <Text>
-                                                                                    {chainIdToName(order?.payments[0]?.blockchain_data?.chain_id)}
+                                                                                    {chainIdToName(
+                                                                                        chainId
+                                                                                    )}
                                                                                 </Text>
                                                                             </Flex>
                                                                         </VStack>
@@ -396,22 +479,55 @@ const Delivered = ({
                                                                         boxShadow="sm"
                                                                         fontFamily="Inter, sans-serif"
                                                                     >
-                                                                        {order.notes.map((note: OrderNote, index: number) => (
-                                                                            <div key={note.id}>
-                                                                                {/* Date in smaller, gray text */}
-                                                                                <Text color="gray.400" fontSize="sm" mb={2}>
-                                                                                    {format(new Date(note.updated_at), 'EEEE, MMMM d, yyyy | h:mm a')}
-                                                                                </Text>
+                                                                        {order.notes.map(
+                                                                            (
+                                                                                note: OrderNote,
+                                                                                index: number
+                                                                            ) => (
+                                                                                <div
+                                                                                    key={
+                                                                                        note.id
+                                                                                    }
+                                                                                >
+                                                                                    {/* Date in smaller, gray text */}
+                                                                                    <Text
+                                                                                        color="gray.400"
+                                                                                        fontSize="sm"
+                                                                                        mb={
+                                                                                            2
+                                                                                        }
+                                                                                    >
+                                                                                        {format(
+                                                                                            new Date(
+                                                                                                note.updated_at
+                                                                                            ),
+                                                                                            'EEEE, MMMM d, yyyy | h:mm a'
+                                                                                        )}
+                                                                                    </Text>
 
-                                                                                {/* The note content */}
-                                                                                <Text color="white">{note.note}</Text>
+                                                                                    {/* The note content */}
+                                                                                    <Text color="white">
+                                                                                        {
+                                                                                            note.note
+                                                                                        }
+                                                                                    </Text>
 
-                                                                                {/* Divider between notes (except after the last one) */}
-                                                                                {index < order.notes.length - 1 && (
-                                                                                    <Divider my={4} borderColor="#272727" />
-                                                                                )}
-                                                                            </div>
-                                                                        ))}
+                                                                                    {/* Divider between notes (except after the last one) */}
+                                                                                    {index <
+                                                                                        order
+                                                                                            .notes
+                                                                                            .length -
+                                                                                            1 && (
+                                                                                        <Divider
+                                                                                            my={
+                                                                                                4
+                                                                                            }
+                                                                                            borderColor="#272727"
+                                                                                        />
+                                                                                    )}
+                                                                                </div>
+                                                                            )
+                                                                        )}
                                                                     </Box>
                                                                 </TabPanel>
                                                             )}

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -254,6 +254,11 @@ const Processing = ({
                         const transactions =
                             historyWithTransaction?.metadata?.transaction;
 
+                        const chainId =
+                            order.payments[0]?.blockchain_data
+                                ?.payment_chain_id ??
+                            order.payments[0]?.blockchain_data?.chain_id;
+
                         return (
                             <div key={order.id}>
                                 {order.items?.map(
@@ -572,16 +577,10 @@ const Processing = ({
                                                                                 </strong>
                                                                                 <Image
                                                                                     src={getChainLogo(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     alt={chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     width={
                                                                                         25
@@ -592,10 +591,7 @@ const Processing = ({
                                                                                 />
                                                                                 <Text>
                                                                                     {chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                 </Text>
                                                                             </Flex>

--- a/hamza-client/src/modules/order/templates/refund.tsx
+++ b/hamza-client/src/modules/order/templates/refund.tsx
@@ -13,7 +13,8 @@ import {
     TabList,
     Tab,
     TabPanels,
-    TabPanel, Divider,
+    TabPanel,
+    Divider,
 } from '@chakra-ui/react';
 import { BsCircleFill } from 'react-icons/bs';
 import RefundCard from '@modules/account/components/refund-card';
@@ -32,7 +33,7 @@ import {
     getChainLogo,
 } from '@modules/order/components/chain-enum/chain-enum';
 import Image from 'next/image';
-import {OrderNote} from './all'
+import { OrderNote } from './all';
 import { format } from 'date-fns';
 
 const Refund = ({
@@ -92,7 +93,12 @@ const Refund = ({
                             0
                         );
                         // Check if we Seller has left a `PUBLIC` note, we're only returning public notes to client.
-                        const hasSellerNotes = order?.notes?.length > 0
+                        const hasSellerNotes = order?.notes?.length > 0;
+
+                        const chainId =
+                            order.payments[0]?.blockchain_data
+                                ?.payment_chain_id ??
+                            order.payments[0]?.blockchain_data?.chain_id;
 
                         return (
                             <Flex
@@ -232,7 +238,7 @@ const Refund = ({
                                                             >
                                                                 Order Timeline
                                                             </Tab>
-                                                            {hasSellerNotes &&
+                                                            {hasSellerNotes && (
                                                                 <Tab
                                                                     _selected={{
                                                                         color: 'primary.green.900',
@@ -241,7 +247,10 @@ const Refund = ({
                                                                         borderColor:
                                                                             'primary.green.900',
                                                                     }}
-                                                                >Seller Note</Tab>}
+                                                                >
+                                                                    Seller Note
+                                                                </Tab>
+                                                            )}
                                                         </TabList>
                                                         <TabPanels>
                                                             <TabPanel>
@@ -270,7 +279,15 @@ const Refund = ({
                                                                         >
                                                                             {order.tracking_number && (
                                                                                 <>
-                                                                                    <Text><b>Tracking Number:</b> {order.tracking_number}</Text>
+                                                                                    <Text>
+                                                                                        <b>
+                                                                                            Tracking
+                                                                                            Number:
+                                                                                        </b>{' '}
+                                                                                        {
+                                                                                            order.tracking_number
+                                                                                        }
+                                                                                    </Text>
                                                                                 </>
                                                                             )}
                                                                             {order
@@ -352,16 +369,10 @@ const Refund = ({
                                                                                 </strong>
                                                                                 <Image
                                                                                     src={getChainLogo(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     alt={chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                     width={
                                                                                         25
@@ -372,10 +383,7 @@ const Refund = ({
                                                                                 />
                                                                                 <Text>
                                                                                     {chainIdToName(
-                                                                                        order
-                                                                                            ?.payments[0]
-                                                                                            ?.blockchain_data
-                                                                                            ?.chain_id
+                                                                                        chainId
                                                                                     )}
                                                                                 </Text>
                                                                             </Flex>
@@ -401,22 +409,55 @@ const Refund = ({
                                                                         boxShadow="sm"
                                                                         fontFamily="Inter, sans-serif"
                                                                     >
-                                                                        {order.notes.map((note: OrderNote, index: number) => (
-                                                                            <div key={note.id}>
-                                                                                {/* Date in smaller, gray text */}
-                                                                                <Text color="gray.400" fontSize="sm" mb={2}>
-                                                                                    {format(new Date(note.updated_at), 'EEEE, MMMM d, yyyy | h:mm a')}
-                                                                                </Text>
+                                                                        {order.notes.map(
+                                                                            (
+                                                                                note: OrderNote,
+                                                                                index: number
+                                                                            ) => (
+                                                                                <div
+                                                                                    key={
+                                                                                        note.id
+                                                                                    }
+                                                                                >
+                                                                                    {/* Date in smaller, gray text */}
+                                                                                    <Text
+                                                                                        color="gray.400"
+                                                                                        fontSize="sm"
+                                                                                        mb={
+                                                                                            2
+                                                                                        }
+                                                                                    >
+                                                                                        {format(
+                                                                                            new Date(
+                                                                                                note.updated_at
+                                                                                            ),
+                                                                                            'EEEE, MMMM d, yyyy | h:mm a'
+                                                                                        )}
+                                                                                    </Text>
 
-                                                                                {/* The note content */}
-                                                                                <Text color="white">{note.note}</Text>
+                                                                                    {/* The note content */}
+                                                                                    <Text color="white">
+                                                                                        {
+                                                                                            note.note
+                                                                                        }
+                                                                                    </Text>
 
-                                                                                {/* Divider between notes (except after the last one) */}
-                                                                                {index < order.notes.length - 1 && (
-                                                                                    <Divider my={4} borderColor="#272727" />
-                                                                                )}
-                                                                            </div>
-                                                                        ))}
+                                                                                    {/* Divider between notes (except after the last one) */}
+                                                                                    {index <
+                                                                                        order
+                                                                                            .notes
+                                                                                            .length -
+                                                                                            1 && (
+                                                                                        <Divider
+                                                                                            my={
+                                                                                                4
+                                                                                            }
+                                                                                            borderColor="#272727"
+                                                                                        />
+                                                                                    )}
+                                                                                </div>
+                                                                            )
+                                                                        )}
                                                                     </Box>
                                                                 </TabPanel>
                                                             )}

--- a/hamza-client/src/modules/order/templates/shipped.tsx
+++ b/hamza-client/src/modules/order/templates/shipped.tsx
@@ -1,5 +1,5 @@
-import React, {useEffect, useState} from 'react';
-import {getSingleBucket} from '@/lib/server';
+import React, { useEffect, useState } from 'react';
+import { getSingleBucket } from '@/lib/server';
 import {
     Box,
     Button,
@@ -16,34 +16,33 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-import {BsCircleFill} from 'react-icons/bs';
+import { BsCircleFill } from 'react-icons/bs';
 import ShippedCard from '@modules/account/components/shipped-card';
 import EmptyState from '@modules/order/components/empty-state';
-import {useQuery, useQueryClient} from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Spinner from '@modules/common/icons/spinner';
-import {debounce, upperCase} from 'lodash';
-import {formatCryptoPrice} from '@lib/util/get-product-price';
+import { debounce, upperCase } from 'lodash';
+import { formatCryptoPrice } from '@lib/util/get-product-price';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import currencyIcons from '@/images/currencies/crypto-currencies';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
-import {OrdersData} from './all';
-import {useOrderTabStore} from '@/zustand/order-tab-state';
+import { OrdersData } from './all';
+import { useOrderTabStore } from '@/zustand/order-tab-state';
 import OrderTimeline from '@modules/order/components/order-timeline';
 import {
     chainIdToName,
     getChainLogo,
 } from '@modules/order/components/chain-enum/chain-enum';
 import Image from 'next/image';
-import { OrderNote } from './all'
+import { OrderNote } from './all';
 import { format } from 'date-fns';
 
-
 const Shipped = ({
-                     customer,
-                     // chainEnabled,
-                     // onSuccess,
-                     isEmpty,
-                 }: {
+    customer,
+    // chainEnabled,
+    // onSuccess,
+    isEmpty,
+}: {
     customer: string;
     // chainEnabled?: boolean;
     // onSuccess?: () => void;
@@ -64,7 +63,7 @@ const Shipped = ({
     const shippedOrder = cachedData?.Shipped || [];
 
     if (isEmpty && shippedOrder?.length === 0) {
-        return <EmptyState/>;
+        return <EmptyState />;
     }
 
     const toggleViewOrder = (orderId: any) => {
@@ -83,7 +82,13 @@ const Shipped = ({
                             0
                         );
                         // Check if we Seller has left a `PUBLIC` note, we're only returning public notes to client.
-                        const hasSellerNotes = order?.notes?.length > 0
+                        const hasSellerNotes = order?.notes?.length > 0;
+
+                        const chainId =
+                            order.payments[0]?.blockchain_data
+                                ?.payment_chain_id ??
+                            order.payments[0]?.blockchain_data?.chain_id;
+
                         return (
                             <div
                                 key={order.id} // Changed from cart_id to id since it's more reliable and unique
@@ -154,7 +159,7 @@ const Shipped = ({
                                                             'flex-end'
                                                         }
                                                         gap={2}
-                                                        mt={{base: 4, md: 0}}
+                                                        mt={{ base: 4, md: 0 }}
                                                         width="100%"
                                                     >
                                                         <Button
@@ -188,7 +193,7 @@ const Shipped = ({
                                                         </Button>
                                                         {order.escrow_status &&
                                                             order.escrow_status !==
-                                                            'released' && (
+                                                                'released' && (
                                                                 <Box
                                                                     as="a"
                                                                     href={`/account/escrow/${order.id}`}
@@ -246,7 +251,7 @@ const Shipped = ({
                                                             >
                                                                 Order Timeline
                                                             </Tab>
-                                                            {hasSellerNotes &&
+                                                            {hasSellerNotes && (
                                                                 <Tab
                                                                     _selected={{
                                                                         color: 'primary.green.900',
@@ -255,10 +260,12 @@ const Shipped = ({
                                                                         borderColor:
                                                                             'primary.green.900',
                                                                     }}
-                                                                >Seller Note</Tab>}
+                                                                >
+                                                                    Seller Note
+                                                                </Tab>
+                                                            )}
                                                         </TabList>
                                                         <TabPanels>
-
                                                             <TabPanel>
                                                                 <HStack
                                                                     align="start"
@@ -271,17 +278,16 @@ const Shipped = ({
                                                                             2
                                                                         }
                                                                     >
-
-
                                                                         <Flex
                                                                             direction={{
                                                                                 base: 'column',
                                                                                 md: 'row',
                                                                             }}
-                                                                            gap={6}
+                                                                            gap={
+                                                                                6
+                                                                            }
                                                                             w="100%"
                                                                         >
-
                                                                             {/* Left Column: Shipping Cost & Subtotal */}
                                                                             <VStack
                                                                                 align="start"
@@ -293,8 +299,14 @@ const Shipped = ({
                                                                                 {/* Stack text vertically */}
                                                                                 {order.tracking_number && (
                                                                                     <>
-                                                                                        <Text><b>Tracking
-                                                                                            Number:</b> {order.tracking_number}
+                                                                                        <Text>
+                                                                                            <b>
+                                                                                                Tracking
+                                                                                                Number:
+                                                                                            </b>{' '}
+                                                                                            {
+                                                                                                order.tracking_number
+                                                                                            }
                                                                                         </Text>
                                                                                     </>
                                                                                 )}
@@ -326,7 +338,7 @@ const Shipped = ({
                                                                                                     ?.price
                                                                                             ),
                                                                                             item.currency_code ??
-                                                                                            'usdc'
+                                                                                                'usdc'
                                                                                         )}{' '}
                                                                                         {upperCase(
                                                                                             item.currency_code
@@ -352,23 +364,21 @@ const Shipped = ({
                                                                                             ?.soOrderInfo
                                                                                             ?.createTime
                                                                                             ? new Date(
-                                                                                                order.external_metadata.tracking.data.soOrderInfo.createTime
-                                                                                            ).toLocaleString(
-                                                                                                undefined,
-                                                                                                {
-                                                                                                    year: 'numeric',
-                                                                                                    month: 'long',
-                                                                                                    day: 'numeric',
-                                                                                                    hour: '2-digit',
-                                                                                                    minute: '2-digit',
-                                                                                                    second: '2-digit',
-                                                                                                }
-                                                                                            )
+                                                                                                  order.external_metadata.tracking.data.soOrderInfo.createTime
+                                                                                              ).toLocaleString(
+                                                                                                  undefined,
+                                                                                                  {
+                                                                                                      year: 'numeric',
+                                                                                                      month: 'long',
+                                                                                                      day: 'numeric',
+                                                                                                      hour: '2-digit',
+                                                                                                      minute: '2-digit',
+                                                                                                      second: '2-digit',
+                                                                                                  }
+                                                                                              )
                                                                                             : 'Date not available'}
                                                                                     </Text>
                                                                                 </Flex>
-
-
                                                                             </VStack>
 
                                                                             {/* Right Column: Order ID & Chain Data */}
@@ -385,18 +395,18 @@ const Shipped = ({
                                                                                     </strong>{' '}
                                                                                     {order?.created_at
                                                                                         ? new Date(
-                                                                                            order.created_at
-                                                                                        ).toLocaleDateString(
-                                                                                            undefined,
-                                                                                            {
-                                                                                                year: 'numeric',
-                                                                                                month: 'long',
-                                                                                                day: 'numeric',
-                                                                                                hour: '2-digit',
-                                                                                                minute: '2-digit',
-                                                                                                second: '2-digit',
-                                                                                            }
-                                                                                        )
+                                                                                              order.created_at
+                                                                                          ).toLocaleDateString(
+                                                                                              undefined,
+                                                                                              {
+                                                                                                  year: 'numeric',
+                                                                                                  month: 'long',
+                                                                                                  day: 'numeric',
+                                                                                                  hour: '2-digit',
+                                                                                                  minute: '2-digit',
+                                                                                                  second: '2-digit',
+                                                                                              }
+                                                                                          )
                                                                                         : 'N/A'}
                                                                                 </Text>
 
@@ -413,11 +423,11 @@ const Shipped = ({
                                                                                         </strong>{' '}
                                                                                         {order?.id &&
                                                                                         typeof order.id ===
-                                                                                        'string'
+                                                                                            'string'
                                                                                             ? order.id.replace(
-                                                                                                /^order_/,
-                                                                                                ''
-                                                                                            ) // Remove "order_" prefix
+                                                                                                  /^order_/,
+                                                                                                  ''
+                                                                                              ) // Remove "order_" prefix
                                                                                             : 'Order ID not available'}
                                                                                     </Text>
                                                                                 </Flex>
@@ -434,16 +444,10 @@ const Shipped = ({
                                                                                     </strong>
                                                                                     <Image
                                                                                         src={getChainLogo(
-                                                                                            order
-                                                                                                ?.payments[0]
-                                                                                                ?.blockchain_data
-                                                                                                ?.chain_id
+                                                                                            chainId
                                                                                         )}
                                                                                         alt={chainIdToName(
-                                                                                            order
-                                                                                                ?.payments[0]
-                                                                                                ?.blockchain_data
-                                                                                                ?.chain_id
+                                                                                            chainId
                                                                                         )}
                                                                                         width={
                                                                                             25
@@ -454,16 +458,12 @@ const Shipped = ({
                                                                                     />
                                                                                     <Text>
                                                                                         {chainIdToName(
-                                                                                            order
-                                                                                                ?.payments[0]
-                                                                                                ?.blockchain_data
-                                                                                                ?.chain_id
+                                                                                            chainId
                                                                                         )}
                                                                                     </Text>
                                                                                 </Flex>
                                                                             </VStack>
                                                                         </Flex>
-
                                                                     </VStack>
                                                                 </HStack>
                                                             </TabPanel>
@@ -487,26 +487,58 @@ const Shipped = ({
                                                                         boxShadow="sm"
                                                                         fontFamily="Inter, sans-serif"
                                                                     >
-                                                                        {order.notes.map((note: OrderNote, index: number) => (
-                                                                            <div key={note.id}>
-                                                                                {/* Date in smaller, gray text */}
-                                                                                <Text color="gray.400" fontSize="sm" mb={2}>
-                                                                                    {format(new Date(note.updated_at), 'EEEE, MMMM d, yyyy | h:mm a')}
-                                                                                </Text>
+                                                                        {order.notes.map(
+                                                                            (
+                                                                                note: OrderNote,
+                                                                                index: number
+                                                                            ) => (
+                                                                                <div
+                                                                                    key={
+                                                                                        note.id
+                                                                                    }
+                                                                                >
+                                                                                    {/* Date in smaller, gray text */}
+                                                                                    <Text
+                                                                                        color="gray.400"
+                                                                                        fontSize="sm"
+                                                                                        mb={
+                                                                                            2
+                                                                                        }
+                                                                                    >
+                                                                                        {format(
+                                                                                            new Date(
+                                                                                                note.updated_at
+                                                                                            ),
+                                                                                            'EEEE, MMMM d, yyyy | h:mm a'
+                                                                                        )}
+                                                                                    </Text>
 
-                                                                                {/* The note content */}
-                                                                                <Text color="white">{note.note}</Text>
+                                                                                    {/* The note content */}
+                                                                                    <Text color="white">
+                                                                                        {
+                                                                                            note.note
+                                                                                        }
+                                                                                    </Text>
 
-                                                                                {/* Divider between notes (except after the last one) */}
-                                                                                {index < order.notes.length - 1 && (
-                                                                                    <Divider my={4} borderColor="#272727" />
-                                                                                )}
-                                                                            </div>
-                                                                        ))}
+                                                                                    {/* Divider between notes (except after the last one) */}
+                                                                                    {index <
+                                                                                        order
+                                                                                            .notes
+                                                                                            .length -
+                                                                                            1 && (
+                                                                                        <Divider
+                                                                                            my={
+                                                                                                4
+                                                                                            }
+                                                                                            borderColor="#272727"
+                                                                                        />
+                                                                                    )}
+                                                                                </div>
+                                                                            )
+                                                                        )}
                                                                     </Box>
                                                                 </TabPanel>
                                                             )}
-
                                                         </TabPanels>
                                                     </Tabs>
                                                 </Box>


### PR DESCRIPTION
**Motivation**
We have to make a distinction between payment chain id and escrow chain id, for an order. The chain on which the order is in escrow used to be the same as the chain on which it was paid for, but not necessarily anymore. 

**Changes**
- The 'blockchain_data' structure of payment now has "chain_id" for backwards compatibility, in addition to the new "payment_chain_id". The former is considered to be equivalent to "escrow chain" while the latter is "payment chain".
- The frontend, when displaying the payment chain, uses the "payment_chain_id" property instead of "chain_id".

**To Test** 
- Pull the branch HAMSTR-560 for Hamza-backend
- Get some test eth on a non-sepolia testnet (I used Base Sepolia)
- Enable the same non-sepolia testnet in .env for Hamza-backend and for Hamza-medusa, as well as for payment-processor and address-store 
- Make sure that CHECKOUT_MODE=ASYNC in Hamza-backend 
- Run everything 
- Do a test checkout (use ETH as currency - to conserve ETH, you might want to modify the DB to make something very cheap) on the second, non-sepolia testnet 
- The checkout should succeed
- Release the escrow for that order (should succeed)
