### PR TITLE
HAMSTR-547: Deeplink to Chat

### DIFF
--- a/hamza-client/src/modules/order/templates/cancelled.tsx
+++ b/hamza-client/src/modules/order/templates/cancelled.tsx
@@ -493,7 +493,12 @@ const Cancelled = ({
                                                                                     }
                                                                                     target="_blank"
                                                                                 >
-                                                                                    <Text fontSize="md">
+                                                                                    <Text
+                                                                                        fontSize="md"
+                                                                                        color={
+                                                                                            '#ADD8E6'
+                                                                                        }
+                                                                                    >
                                                                                         <strong>
                                                                                             Chat
                                                                                             with

--- a/hamza-client/src/modules/order/templates/cancelled.tsx
+++ b/hamza-client/src/modules/order/templates/cancelled.tsx
@@ -488,7 +488,7 @@ const Cancelled = ({
                                                                                         process
                                                                                             .env
                                                                                             .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
                                                                                             : 'https://support.hamza.market/help/1568263160'
                                                                                     }
                                                                                     target="_blank"

--- a/hamza-client/src/modules/order/templates/cancelled.tsx
+++ b/hamza-client/src/modules/order/templates/cancelled.tsx
@@ -476,6 +476,32 @@ const Cancelled = ({
                                                                                     )}
                                                                                 </Text>
                                                                             </Flex>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text fontSize="md">
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
+                                                                            </Flex>
                                                                         </VStack>
                                                                     </Flex>
                                                                 </VStack>

--- a/hamza-client/src/modules/order/templates/delivered.tsx
+++ b/hamza-client/src/modules/order/templates/delivered.tsx
@@ -467,7 +467,7 @@ const Delivered = ({
                                                                                         process
                                                                                             .env
                                                                                             .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
                                                                                             : 'https://support.hamza.market/help/1568263160'
                                                                                     }
                                                                                     target="_blank"

--- a/hamza-client/src/modules/order/templates/delivered.tsx
+++ b/hamza-client/src/modules/order/templates/delivered.tsx
@@ -472,7 +472,12 @@ const Delivered = ({
                                                                                     }
                                                                                     target="_blank"
                                                                                 >
-                                                                                    <Text fontSize="md">
+                                                                                    <Text
+                                                                                        fontSize="md"
+                                                                                        color={
+                                                                                            '#ADD8E6'
+                                                                                        }
+                                                                                    >
                                                                                         <strong>
                                                                                             Chat
                                                                                             with

--- a/hamza-client/src/modules/order/templates/delivered.tsx
+++ b/hamza-client/src/modules/order/templates/delivered.tsx
@@ -12,13 +12,12 @@ import {
     TabPanel,
     VStack,
 } from '@chakra-ui/react';
-import Spinner from '@modules/common/icons/spinner';
 import { addToCart } from '@modules/cart/actions';
 import toast from 'react-hot-toast';
 import DeliveredCard from '@modules/account/components/delivered-card';
 import EmptyState from '@modules/order/components/empty-state';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import React, { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import React, { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
@@ -455,6 +454,32 @@ const Delivered = ({
                                                                                         chainId
                                                                                     )}
                                                                                 </Text>
+                                                                            </Flex>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text fontSize="md">
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
                                                                             </Flex>
                                                                         </VStack>
                                                                     </Flex>

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -31,18 +31,15 @@ import {
 import { formatCryptoPrice } from '@lib/util/get-product-price';
 import { format } from 'date-fns';
 import EmptyState from '@modules/order/components/empty-state';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import Spinner from '@modules/common/icons/spinner';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import OrderTimeline from '@modules/order/components/order-timeline';
 import ProcessingOrderCard from '@modules/account/components/processing-order-card';
-import { BsCircleFill } from 'react-icons/bs';
 import Image from 'next/image';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
 import { OrdersData, OrderNote, HistoryMeta, OrderHistory } from './all';
 import { useOrderTabStore } from '@/zustand/order-tab-state';
 import { upperCase } from 'lodash';
-import LocalizedClientLink from '@modules/common/components/localized-client-link';
 
 /**
  * The Processing component displays and manages the customer's processing orders, allowing users to view order details,
@@ -594,6 +591,32 @@ const Processing = ({
                                                                                         chainId
                                                                                     )}
                                                                                 </Text>
+                                                                            </Flex>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text fontSize="md">
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
                                                                             </Flex>
                                                                         </VStack>
                                                                     </Flex>

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -542,7 +542,7 @@ const Processing = ({
                                                                                         process
                                                                                             .env
                                                                                             .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
                                                                                             : 'https://support.hamza.market/help/1568263160'
                                                                                     }
                                                                                     target="_blank"

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -530,32 +530,6 @@ const Processing = ({
                                                                                     item.currency_code
                                                                                 )}
                                                                             </Text>
-
-                                                                            <Flex
-                                                                                align="center"
-                                                                                gap={
-                                                                                    2
-                                                                                }
-                                                                            >
-                                                                                <a
-                                                                                    href={
-                                                                                        process
-                                                                                            .env
-                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
-                                                                                            : 'https://support.hamza.market/help/1568263160'
-                                                                                    }
-                                                                                    target="_blank"
-                                                                                >
-                                                                                    <Text fontSize="md">
-                                                                                        <strong>
-                                                                                            Chat
-                                                                                            with
-                                                                                            Merchant
-                                                                                        </strong>{' '}
-                                                                                    </Text>
-                                                                                </a>
-                                                                            </Flex>
                                                                         </VStack>
 
                                                                         {/* Right Column: Order ID & Chain Data */}
@@ -617,6 +591,37 @@ const Processing = ({
                                                                                         chainId
                                                                                     )}
                                                                                 </Text>
+                                                                            </Flex>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text
+                                                                                        fontSize="md"
+                                                                                        color={
+                                                                                            '#ADD8E6'
+                                                                                        }
+                                                                                    >
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
                                                                             </Flex>
                                                                         </VStack>
                                                                     </Flex>

--- a/hamza-client/src/modules/order/templates/processing.tsx
+++ b/hamza-client/src/modules/order/templates/processing.tsx
@@ -530,6 +530,32 @@ const Processing = ({
                                                                                     item.currency_code
                                                                                 )}
                                                                             </Text>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text fontSize="md">
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
+                                                                            </Flex>
                                                                         </VStack>
 
                                                                         {/* Right Column: Order ID & Chain Data */}
@@ -591,32 +617,6 @@ const Processing = ({
                                                                                         chainId
                                                                                     )}
                                                                                 </Text>
-                                                                            </Flex>
-
-                                                                            <Flex
-                                                                                align="center"
-                                                                                gap={
-                                                                                    2
-                                                                                }
-                                                                            >
-                                                                                <a
-                                                                                    href={
-                                                                                        process
-                                                                                            .env
-                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
-                                                                                            : 'https://support.hamza.market/help/1568263160'
-                                                                                    }
-                                                                                    target="_blank"
-                                                                                >
-                                                                                    <Text fontSize="md">
-                                                                                        <strong>
-                                                                                            Chat
-                                                                                            with
-                                                                                            Merchant
-                                                                                        </strong>{' '}
-                                                                                    </Text>
-                                                                                </a>
                                                                             </Flex>
                                                                         </VStack>
                                                                     </Flex>

--- a/hamza-client/src/modules/order/templates/refund.tsx
+++ b/hamza-client/src/modules/order/templates/refund.tsx
@@ -1,11 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { getSingleBucket } from '@/lib/server';
 import {
     Flex,
     Box,
     Collapse,
-    HStack,
-    Icon,
     Text,
     VStack,
     Button,
@@ -16,13 +13,11 @@ import {
     TabPanel,
     Divider,
 } from '@chakra-ui/react';
-import { BsCircleFill } from 'react-icons/bs';
 import RefundCard from '@modules/account/components/refund-card';
 import EmptyState from '@modules/order/components/empty-state';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
-import Spinner from '@modules/common/icons/spinner';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { debounce, upperCase } from 'lodash';
+import { useQueryClient } from '@tanstack/react-query';
+import { upperCase } from 'lodash';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
 import { OrdersData } from './all';
@@ -386,6 +381,32 @@ const Refund = ({
                                                                                         chainId
                                                                                     )}
                                                                                 </Text>
+                                                                            </Flex>
+
+                                                                            <Flex
+                                                                                align="center"
+                                                                                gap={
+                                                                                    2
+                                                                                }
+                                                                            >
+                                                                                <a
+                                                                                    href={
+                                                                                        process
+                                                                                            .env
+                                                                                            .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            : 'https://support.hamza.market/help/1568263160'
+                                                                                    }
+                                                                                    target="_blank"
+                                                                                >
+                                                                                    <Text fontSize="md">
+                                                                                        <strong>
+                                                                                            Chat
+                                                                                            with
+                                                                                            Merchant
+                                                                                        </strong>{' '}
+                                                                                    </Text>
+                                                                                </a>
                                                                             </Flex>
                                                                         </VStack>
                                                                     </Flex>

--- a/hamza-client/src/modules/order/templates/refund.tsx
+++ b/hamza-client/src/modules/order/templates/refund.tsx
@@ -394,7 +394,7 @@ const Refund = ({
                                                                                         process
                                                                                             .env
                                                                                             .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                            ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
                                                                                             : 'https://support.hamza.market/help/1568263160'
                                                                                     }
                                                                                     target="_blank"

--- a/hamza-client/src/modules/order/templates/refund.tsx
+++ b/hamza-client/src/modules/order/templates/refund.tsx
@@ -399,7 +399,12 @@ const Refund = ({
                                                                                     }
                                                                                     target="_blank"
                                                                                 >
-                                                                                    <Text fontSize="md">
+                                                                                    <Text
+                                                                                        fontSize="md"
+                                                                                        color={
+                                                                                            '#ADD8E6'
+                                                                                        }
+                                                                                    >
                                                                                         <strong>
                                                                                             Chat
                                                                                             with

--- a/hamza-client/src/modules/order/templates/shipped.tsx
+++ b/hamza-client/src/modules/order/templates/shipped.tsx
@@ -470,7 +470,7 @@ const Shipped = ({
                                                                                             process
                                                                                                 .env
                                                                                                 .NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                                                                                ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                                ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket&order=${order.id}`
                                                                                                 : 'https://support.hamza.market/help/1568263160'
                                                                                         }
                                                                                         target="_blank"

--- a/hamza-client/src/modules/order/templates/shipped.tsx
+++ b/hamza-client/src/modules/order/templates/shipped.tsx
@@ -475,7 +475,12 @@ const Shipped = ({
                                                                                         }
                                                                                         target="_blank"
                                                                                     >
-                                                                                        <Text fontSize="md">
+                                                                                        <Text
+                                                                                            fontSize="md"
+                                                                                            color={
+                                                                                                '#ADD8E6'
+                                                                                            }
+                                                                                        >
                                                                                             <strong>
                                                                                                 Chat
                                                                                                 with

--- a/hamza-client/src/modules/order/templates/shipped.tsx
+++ b/hamza-client/src/modules/order/templates/shipped.tsx
@@ -7,7 +7,6 @@ import {
     Divider,
     Flex,
     HStack,
-    Icon,
     Tab,
     TabList,
     TabPanel,
@@ -16,15 +15,12 @@ import {
     Text,
     VStack,
 } from '@chakra-ui/react';
-import { BsCircleFill } from 'react-icons/bs';
 import ShippedCard from '@modules/account/components/shipped-card';
 import EmptyState from '@modules/order/components/empty-state';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import Spinner from '@modules/common/icons/spinner';
-import { debounce, upperCase } from 'lodash';
+import { useQueryClient } from '@tanstack/react-query';
+import { upperCase } from 'lodash';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
 import DynamicOrderStatus from '@modules/order/templates/dynamic-order-status';
-import currencyIcons from '@/images/currencies/crypto-currencies';
 import OrderTotalAmount from '@modules/order/templates/order-total-amount';
 import { OrdersData } from './all';
 import { useOrderTabStore } from '@/zustand/order-tab-state';
@@ -461,6 +457,32 @@ const Shipped = ({
                                                                                             chainId
                                                                                         )}
                                                                                     </Text>
+                                                                                </Flex>
+
+                                                                                <Flex
+                                                                                    align="center"
+                                                                                    gap={
+                                                                                        2
+                                                                                    }
+                                                                                >
+                                                                                    <a
+                                                                                        href={
+                                                                                            process
+                                                                                                .env
+                                                                                                .NEXT_PUBLIC_HAMZA_CHAT_LINK
+                                                                                                ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${order.store.handle}.hamzamarket`
+                                                                                                : 'https://support.hamza.market/help/1568263160'
+                                                                                        }
+                                                                                        target="_blank"
+                                                                                    >
+                                                                                        <Text fontSize="md">
+                                                                                            <strong>
+                                                                                                Chat
+                                                                                                with
+                                                                                                Merchant
+                                                                                            </strong>{' '}
+                                                                                        </Text>
+                                                                                    </a>
                                                                                 </Flex>
                                                                             </VStack>
                                                                         </Flex>

--- a/hamza-client/src/modules/products/components/product-preview/components/store-banner/store-banner.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/store-banner/store-banner.tsx
@@ -107,7 +107,7 @@ const StoreBanner = (props: StoreProps) => {
                     <a
                         href={
                             process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?channel=${props.storeHandle}`
+                                ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${props.storeHandle}.hamzamarket`
                                 : 'https://support.hamza.market/help/1568263160'
                         }
                         target="_blank"

--- a/hamza-client/src/modules/store/templates/store-content.tsx
+++ b/hamza-client/src/modules/store/templates/store-content.tsx
@@ -285,7 +285,7 @@ export default function StoreContent({ params }: { params: { slug: string } }) {
                             <a
                                 href={
                                     process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK
-                                        ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?channel=${storeHandle}`
+                                        ? `${process.env.NEXT_PUBLIC_HAMZA_CHAT_LINK}?target=${storeHandle}.hamzamarket`
                                         : 'https://support.hamza.market/help/1568263160'
                                 }
                                 target="_blank"


### PR DESCRIPTION
**Motivation**
HNS-chat has a deeplink format. In this PR I added a 'Chat with Merchant' link to order details panel, that has that deeplink structure. 

**Changes**
Changed links to chat from store page, to follow new format
Added link to chat on order details page, for each order

**To Test**
Look at orders panel, under Order Details 
Click the link 

NOTE: requires this .env key: 
NEXT_PUBLIC_HAMZA_CHAT_LINK=https://hns-chat.hamza.market