### PR TITLE
HAMSTR-566: Fulfillment status on Escrow page

### DIFF
--- a/hamza-client/src/modules/order/components/order-overview/escrow-status.tsx
+++ b/hamza-client/src/modules/order/components/order-overview/escrow-status.tsx
@@ -32,8 +32,17 @@ function getEscrowStatus(payment: PaymentDefinition): string {
     return 'in escrow';
 }
 
-const EscrowStatus: React.FC<EscrowStatusProps> = ({ payment }: { payment: PaymentDefinition | null }) => {
-    const status = payment ? getEscrowStatus(payment) : '-';
+const capitalizeFirstLetter = (str?: string) =>
+    str ? str.replace(/(?:^|\s)\S/g, (match) => match.toUpperCase()) : ''; // Capitalize every word's first char
+
+const EscrowStatus: React.FC<EscrowStatusProps> = ({
+    payment,
+}: {
+    payment: PaymentDefinition | null;
+}) => {
+    const status = payment
+        ? capitalizeFirstLetter(getEscrowStatus(payment))
+        : '-';
 
     return (
         <div className="p-4 bg-[#242424] rounded-lg shadow-sm">

--- a/hamza-client/src/modules/order/components/order-overview/order-component.tsx
+++ b/hamza-client/src/modules/order/components/order-overview/order-component.tsx
@@ -61,7 +61,7 @@ export const OrderComponent = ({ order }: { order: Order }) => {
                             {index === 0 ? (
                                 <DynamicOrderStatus
                                     paymentStatus={order.payment_status}
-                                    paymentType={'Delivered'}
+                                    fulfillmentStatus={order.fulfillment_status}
                                 />
                             ) : null}
                             <DeliveredCard

--- a/hamza-client/src/modules/order/components/order-overview/order-component.tsx
+++ b/hamza-client/src/modules/order/components/order-overview/order-component.tsx
@@ -61,7 +61,7 @@ export const OrderComponent = ({ order }: { order: Order }) => {
                             {index === 0 ? (
                                 <DynamicOrderStatus
                                     paymentStatus={order.payment_status}
-                                    fulfillmentStatus={order.fulfillment_status}
+                                    paymentType={order.fulfillment_status}
                                 />
                             ) : null}
                             <DeliveredCard

--- a/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
+++ b/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
@@ -5,10 +5,10 @@ import { IoMdInformationCircleOutline } from 'react-icons/io';
 
 const DynamicOrderStatus = ({
     paymentStatus,
-    fulfillmentStatus,
+    paymentType: paymentType,
 }: {
     paymentStatus?: string;
-    fulfillmentStatus?: string;
+    paymentType?: string;
 }) => {
     const capitalizeFirstLetter = (str?: string) =>
         str ? str.replace(/(?:^|\s)\S/g, (match) => match.toUpperCase()) : ''; // Capitalize every word's first char
@@ -44,7 +44,7 @@ const DynamicOrderStatus = ({
             />
 
             <Text color={'primary.green.900'}>
-                {capitalizeFirstLetter(removeUnderscores(fulfillmentStatus))}
+                {capitalizeFirstLetter(removeUnderscores(paymentType))}
             </Text>
         </Flex>
     );

--- a/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
+++ b/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
@@ -5,13 +5,15 @@ import { IoMdInformationCircleOutline } from 'react-icons/io';
 
 const DynamicOrderStatus = ({
     paymentStatus,
-    paymentType,
+    fulfillmentStatus,
 }: {
     paymentStatus?: string;
-    paymentType?: string;
+    fulfillmentStatus?: string;
 }) => {
     const capitalizeFirstLetter = (str?: string) =>
-        str ? str.charAt(0).toUpperCase() + str.slice(1) : ''; // Handle undefined
+        str ? str.replace(/(?:^|\s)\S/g, (match) => match.toUpperCase()) : ''; // Capitalize every word's first char
+
+    const removeUnderscores = (s?: string) => (s ? s.replaceAll('_', ' ') : '');
 
     return (
         <Flex
@@ -41,7 +43,9 @@ const DynamicOrderStatus = ({
                 mx={1}
             />
 
-            <Text color={'primary.green.900'}>{paymentType}</Text>
+            <Text color={'primary.green.900'}>
+                {capitalizeFirstLetter(removeUnderscores(fulfillmentStatus))}
+            </Text>
         </Flex>
     );
 };


### PR DESCRIPTION
**Motivation**
The order escrow page looks good, but I’ve noticed that it says “Delivered” for every order, even if I know the order hasn’t yet been delivered. I suspect that the “Delivered” field there may be hard-coded. 

**Changes**
The 'Delivered' was hard-coded. I changed that paymentType field to be fulfillmentStatus, and put in the order's fulfillment status as the value. 

**To Test**
- Place an async order 
- View the escrow release page for the order