### PR TITLE
HAMSTR-595: Error paying manually with "ETH"

### DIFF
--- a/hamza-client/src/lib/util/get-product-price.ts
+++ b/hamza-client/src/lib/util/get-product-price.ts
@@ -100,7 +100,8 @@ export function getProductPrice({
 
 export function formatCryptoPrice(
     amount: number,
-    currencyCode: string = 'usdc'
+    currencyCode: string = 'usdc',
+    roundToPrecision: boolean = true
 ): string | number {
     try {
         if (!currencyCode?.length) currencyCode = 'usdc';
@@ -113,9 +114,11 @@ export function formatCryptoPrice(
         let output =
             displayPrecision <= 2
                 ? Number(amount).toFixed(2)
-                : parseFloat(Number(amount).toFixed(displayPrecision));
+                : roundToPrecision
+                  ? parseFloat(Number(amount).toFixed(displayPrecision))
+                  : parseFloat(Number(amount).toString());
 
-        if (displayPrecision > 2) {
+        if (displayPrecision > 2 && roundToPrecision) {
             output = limitPrecision(
                 parseFloat(output.toString()),
                 currencyPrecision.display

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -352,7 +352,8 @@ const OrderProcessing = ({
                                             <Text ml="0.4rem" color="white">
                                                 {formatCryptoPrice(
                                                     paymentTotal ?? 0,
-                                                    currencyCode ?? 'usdc'
+                                                    currencyCode ?? 'usdc',
+                                                    false
                                                 )}
                                             </Text>
                                         </Flex>
@@ -615,7 +616,8 @@ const OrderProcessing = ({
                                                                 paymentTotal ??
                                                                     0,
                                                                 currencyCode ??
-                                                                    'usdc'
+                                                                    'usdc',
+                                                                false
                                                             )}
                                                         </Text>
                                                     </VStack>
@@ -775,7 +777,8 @@ const OrderProcessing = ({
                                         <Text ml="0.4rem" color="white">
                                             {formatCryptoPrice(
                                                 paymentTotal ?? 0,
-                                                currencyCode ?? 'usdc'
+                                                currencyCode ?? 'usdc',
+                                                false
                                             )}
                                         </Text>
                                     </Flex>


### PR DESCRIPTION
The issue is in how the ETH price is displayed. 

In the example that I reproduced, the price to pay was 0.00005195. 

The price displayed (to pay), however, was 0.00005

Paying this amount results in “partial” payment. 

So the solution is to display the price more precisely