### PR TITLE
HAMSTR-593 - confirmation page escrow links

### DIFF
--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -240,7 +240,6 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                     <Button
                                         as={Link}
                                         href={`/account/escrow/${order.id}`}
-                                        target="_blank"
                                         size="sm"
                                         bg="gray.700"
                                         color="white"


### PR DESCRIPTION
Problem:
- Order confirmation "View Escrow" links opens up a new window/tab
- In metamask, if you are logging in using metamask browser on mobile, clicking "View Escrow" will cause open a new browser window, outside of metamask.  Most likely, that user is not logged in, and since "Escrow" page requires a logged in user, an error will occur.

Testing:
1. Make a purchase
2. On order confirmation page, click "View Escrow"
3. The user should remain in the same browser window, and redirect to Escrow page
4. (Bonus) try this on mobile with metamask wallet