### PR TITLE
HAMSTR-603 : Inconsistent Order id format ('order_')

### DIFF
--- a/hamza-client/src/lib/util/order-escrow.ts
+++ b/hamza-client/src/lib/util/order-escrow.ts
@@ -196,8 +196,9 @@ function validatePaymentExists(
     payment: PaymentDefinition | null,
     orderId: string
 ) {
+    const displayOrderId = orderId.replace(/^order_/, '');
     if (!payment || !paymentIsValid(payment)) {
-        throw new Error(`Payment ${orderId} not found.`);
+        throw new Error(`Payment ${displayOrderId} not found.`);
     }
 }
 
@@ -205,9 +206,10 @@ function validatePaymentNotReleased(
     payment: PaymentDefinition | null,
     orderId: string
 ) {
+    const displayOrderId = orderId.replace(/^order_/, '');
     if (payment?.released) {
         throw new Error(
-            `Escrow payment for ${orderId} has already been released.`
+            `Escrow payment for ${displayOrderId} has already been released.`
         );
     }
 }
@@ -216,9 +218,10 @@ function validatePaymentNotReleasedBySeller(
     payment: PaymentDefinition | null,
     orderId: string
 ) {
+    const displayOrderId = orderId.replace(/^order_/, '');
     if (payment?.receiverReleased) {
         throw new Error(
-            `Escrow payment for ${orderId} has already been released by the seller.`
+            `Escrow payment for ${displayOrderId} has already been released by the seller.`
         );
     }
 }
@@ -228,13 +231,14 @@ function validateRefundAmount(
     orderId: string,
     amount: BigNumberish
 ) {
+    const displayOrderId = orderId.replace(/^order_/, '');
     const refundableAmt =
         BigInt(payment?.amount.toString() ?? '0') -
         BigInt(payment?.amountRefunded.toString() ?? '0');
 
     if (refundableAmt < BigInt(amount.toString())) {
         throw new Error(
-            `Amount of ${amount} exceeds the refundable amount of ${refundableAmt} for ${orderId}.`
+            `Amount of ${amount} exceeds the refundable amount of ${refundableAmt} for ${displayOrderId}.`
         );
     }
 }

--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -233,7 +233,7 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                             height={6}
                                             mr={2}
                                         />
-                                        <Text>#...{order.id.slice(-10)}</Text> -{' '}
+                                        <Text marginRight={2}>#...{order.id.replace(/^order_/, '').slice(-10)}</Text>
                                         {order.store?.name}
                                     </Flex>
 

--- a/hamza-client/src/modules/order-processing/components/OrderItem.tsx
+++ b/hamza-client/src/modules/order-processing/components/OrderItem.tsx
@@ -77,10 +77,10 @@ const OrderItem = ({
                 <HStack spacing={3}>
                     <Icon as={FaBox} color="white" />
                     <Text color="white" display={{ base: 'none', md: 'block' }}>
-                        {`${order.id} - ${order.store.name}`}
+                        {`${order.id.replace(/^order_/, '')} - ${order.store.name}`}
                     </Text>
                     <Text color="white" display={{ base: 'block', md: 'none' }}>
-                        {`...${order.id.slice(-10)}`}
+                        {`...${order.id.replace(/^order_/, '').slice(-10)}`}
                         <br />
                         {order.store.name}
                     </Text>

--- a/hamza-client/src/modules/order/components/order-details/index.tsx
+++ b/hamza-client/src/modules/order/components/order-details/index.tsx
@@ -87,7 +87,7 @@ const OrderDetails = ({ cart, showStatus }: OrderDetailsProps) => {
                             key={orderId}
                             fontSize={{ base: '14px', md: '16px' }}
                         >
-                            {orderId}
+                            {orderId.replace(/^order_/, '')}
                         </Text>
                     ))}
                 </Flex>

--- a/hamza-client/src/modules/order/templates/escrow.tsx
+++ b/hamza-client/src/modules/order/templates/escrow.tsx
@@ -119,7 +119,7 @@ export const Escrow = ({
                     {/* Display order details */}
                     {order && (
                         <>
-                            {order.id}
+                            {order.id.replace(/^order_/, '')}
                             <OrderComponent order={order} />
                         </>
                     )}
@@ -147,7 +147,7 @@ export const Escrow = ({
                                         <Flex direction="column" align="center" justify="center" my={4} p={5}
                                             borderWidth="1px" borderColor="whiteAlpha.300" borderRadius="md">
                                             <Text mb={2}>
-                                                Order found ({order.id}), waiting for escrow setup to complete
+                                                Order found {order.id.replace(/^order_/, '')}, waiting for escrow setup to complete
                                             </Text>
                                             <Text fontSize="sm" color="whiteAlpha.700">
                                                 Your payment is being processed. This may take a few moments.


### PR DESCRIPTION
**Motivation :**

In some places, when displaying order id, we remove the “order_” prefix. However, in other places, we display the “order_” prefix. 

**Changes:**

1. Removed "order_" prefix from all order ID displays in UI components
2. Updated error messages to display order IDs without the prefix

**Testing:**

1. Go to Manage Account → Orders → View Escrow Detail - verify order IDs appear without the "order_" prefix
2. Check Payment Processor page - confirm all order ID references display without the prefix
3. Verify consistent formatting in both desktop and mobile views