### PR TITLE
HAMSTR-529 + HAMSTR-632: address hotfix and phone number not required

### DIFF
--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/utils/fetch-cart-for-checkout.ts
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/utils/fetch-cart-for-checkout.ts
@@ -1,7 +1,7 @@
 import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
 import { CartWithCheckoutStep } from '@/types/global';
 import { LineItem } from '@medusajs/medusa';
-import { setBestShippingAddress } from '@/lib/server';
+import { addDefaultShippingMethod, setBestShippingAddress } from '@/lib/server';
 
 /**
  * Fetches the cart and enriches the line items with product data
@@ -30,6 +30,14 @@ export const fetchCartForCheckout = async (
     if (!cart?.shipping_address_id) {
         const address = await setBestShippingAddress(cart);
         if (address) {
+            cart = await retrieveCart(cartId);
+        }
+    }
+
+    // add default shipping method
+    if (!cart?.shipping_methods.length) {
+        const shippingMethod = await addDefaultShippingMethod(cartId);
+        if (shippingMethod) {
             cart = await retrieveCart(cartId);
         }
     }

--- a/hamza-client/src/modules/account/actions.ts
+++ b/hamza-client/src/modules/account/actions.ts
@@ -215,9 +215,7 @@ export async function addCustomerShippingAddress(
     } as StorePostCustomersCustomerAddressesReq;
 
     try {
-        await addShippingAddress(customer).then(() => {
-            revalidateTag('customer');
-        });
+        await addShippingAddress(customer);
         return { success: true, error: null };
     } catch (error: any) {
         return { success: false, error: error.toString() };

--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -168,13 +168,14 @@ const AddressModal: React.FC<AddressModalProps> = ({
     };
 
     const validatePhone = (phone: string): boolean => {
+        // If phone is empty, skip validation
+        if (!phone) {
+            setPhoneError('');
+            return true;
+        }
+
         // Remove spaces and dashes for validation
         const cleanPhone = phone.replace(/[\s-]/g, '');
-
-        // if (!phone) {
-        //     setPhoneError('Phone number is required');
-        //     return false;
-        // }
 
         // Check if the cleaned number contains only digits
         if (!/^\d+$/.test(cleanPhone)) {
@@ -536,10 +537,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
                                 gap="4"
                                 flexDir={{ base: 'column', md: 'row' }}
                             >
-                                <FormControl
-                                    isRequired
-                                    isInvalid={!!phoneError}
-                                >
+                                <FormControl isInvalid={!!phoneError}>
                                     <Input
                                         placeholder="Phone Number"
                                         height={'50px'}

--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -171,10 +171,10 @@ const AddressModal: React.FC<AddressModalProps> = ({
         // Remove spaces and dashes for validation
         const cleanPhone = phone.replace(/[\s-]/g, '');
 
-        if (!phone) {
-            setPhoneError('Phone number is required');
-            return false;
-        }
+        // if (!phone) {
+        //     setPhoneError('Phone number is required');
+        //     return false;
+        // }
 
         // Check if the cleaned number contains only digits
         if (!/^\d+$/.test(cleanPhone)) {

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -422,7 +422,8 @@ const CryptoPaymentButton = ({
     const disableButton =
         isCartEmpty ||
         isUpdatingCart ||
-        (isMissingAddress && isMissingShippingMethod);
+        isMissingAddress ||
+        isMissingShippingMethod;
 
     const getButtonText = () => {
         if (isCartEmpty) return 'Add products to order';


### PR DESCRIPTION
Problem:
- When a new user creates an address and saves - the application incorrectly handles address creation (multiple addresses created), and all addresses created contains the customer_id (making the user account contain multiple addresses if they go to address book)

Note about address logic:
(1) Each time a cart has an address created, a new address record is created (even if not saved) without "customer_id" (this will ALWAYS BE CREATED for each cart)
(2) If the user decides to "save" the address, a new address record is created with the "customer_id" - so in this case, there are 2 address records created in the database
(3) If the user wants to modify the address info in the cart, it modifies the address created in (1)
(4) If the user modifies the address and selected "overwrite address", it does the same thing as (3) - essentially rendering the "overwrite address" checkbox useless.  I feel like this is a bug, but not 100% sure.  I think the overwrite address is suppose to modify the "saved address", but not 100% sure.  If this is the case, will need to do more refactoring so that will work, plus an update with the button text like "Update Saved Address", and the other button "Save New Address"

**Test**
- Create a new user
- Buy a new item
- Create address and select "Save"
- The address should display
- Edit address should provide a dropdown of the saved address
