### PR TITLE
Using 3rd party images in cart

### DIFF
--- a/hamza-client/src/modules/products/components/thumbnail/index.tsx
+++ b/hamza-client/src/modules/products/components/thumbnail/index.tsx
@@ -70,6 +70,7 @@ const ImageOrPlaceholder = ({
             quality={50}
             sizes="(max-width: 576px) 280px, (max-width: 768px) 360px, (max-width: 992px) 480px, 800px"
             fill
+            unoptimized
         />
     ) : (
         <div className="w-full h-full absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
Problem:
The cart is using the Next image component.  When using this component, images served from outside of its allowed list will fail.  We could update the next.config.js file, OR, simply allow just override the need to used an optimized version. 

Solution:
- at the moment, I simply used the unoptimized version.  Moving forward, if we do allow 3rd party images, we need to consider the impact of loading the cart and checkout pages when there are lots of products  in cart, as there is a performance hit.  

**Test:**
- add New York Bar Store item to cart
- view cart and checkout pages
- check to see if thumbnail displays