### PR TITLE
HAMSTR-627 escrow back button

### DIFF
--- a/hamza-client/src/modules/account/components/order-overview/index.tsx
+++ b/hamza-client/src/modules/account/components/order-overview/index.tsx
@@ -13,19 +13,34 @@ import Delivered from '@modules/order/templates/delivered';
 import Cancelled from '@modules/order/templates/cancelled';
 import Refund from '@/modules/order/templates/refunded';
 import { useOrderTabStore } from '@/zustand/order-tab-state';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { OrderTabsStyle } from './order-tabs-style';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 const OrderOverview = ({ customer }: { customer: any }) => {
     const orderActiveTab = useOrderTabStore((state) => state.orderActiveTab);
-
     const setOrderActiveTab = useOrderTabStore(
         (state) => state.setOrderActiveTab
     );
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    // Initialize tab from URL parameter
+    useEffect(() => {
+        const tabParam = searchParams.get('tab');
+        if (tabParam && Object.values(TABS).includes(tabParam)) {
+            setOrderActiveTab(tabParam);
+        }
+    }, [searchParams, setOrderActiveTab]);
 
     const handleTabChange = (tab: string) => {
         if (orderActiveTab !== tab) {
             setOrderActiveTab(tab);
+            // Update URL with new tab
+            const params = new URLSearchParams(searchParams);
+            params.set('tab', tab);
+            router.push(`${pathname}?${params.toString()}`);
         }
     };
 

--- a/hamza-client/src/modules/order/templates/escrow.tsx
+++ b/hamza-client/src/modules/order/templates/escrow.tsx
@@ -91,7 +91,7 @@ export const Escrow = ({
                 position="absolute"
                 top="16px"
                 right="16px"
-                onClick={() => router.back()}
+                onClick={() => router.push('/account/orders?tab=Refund')}
                 variant="ghost"
                 color="white"
                 _hover={{ bg: 'whiteAlpha.200' }}

--- a/hamza-client/src/modules/order/templates/escrow.tsx
+++ b/hamza-client/src/modules/order/templates/escrow.tsx
@@ -1,10 +1,7 @@
 'use client';
-import {
-    Box,
-    Flex,
-    Text,
-} from '@chakra-ui/react';
+import { Box, Flex, Text, IconButton, Button } from '@chakra-ui/react';
 import { MdOutlineHandshake } from 'react-icons/md';
+import { IoArrowBack } from 'react-icons/io5';
 import { OrderComponent } from '@/modules/order/components/order-overview/order-component';
 import { useEffect, useState, useRef } from 'react';
 import { ReleaseEscrowDialog } from '../components/escrow/release-escrow-dialog';
@@ -15,6 +12,7 @@ import { ModalCoverWalletConnect } from '@/modules/common/components/modal-cover
 import { Customer } from '@/app/[countryCode]/(main)/account/@dashboard/escrow/[id]/page';
 import { useQuery } from '@tanstack/react-query';
 import { getEscrowPaymentData } from '@/lib/server';
+import { useRouter } from 'next/navigation';
 
 export const Escrow = ({
     id,
@@ -28,10 +26,13 @@ export const Escrow = ({
     const { isConnected } = useAccount();
     const [isClient, setIsClient] = useState<boolean>(false);
     const startTimeRef = useRef(Date.now());
-    
-    const { data: escrowPayment, isLoading: isLoadingEscrowPayment, isFetching } = useQuery<
-        PaymentDefinition | null
-    >({
+    const router = useRouter();
+
+    const {
+        data: escrowPayment,
+        isLoading: isLoadingEscrowPayment,
+        isFetching,
+    } = useQuery<PaymentDefinition | null>({
         queryKey: ['escrowPayment', id],
         queryFn: async () => {
             if (!order) return null;
@@ -49,9 +50,9 @@ export const Escrow = ({
         refetchInterval: () => {
             const elapsed = Date.now() - startTimeRef.current;
             if (elapsed > 120000) {
-                return false; 
+                return false;
             }
-            return 15000; 
+            return 15000;
         },
     });
 
@@ -83,7 +84,24 @@ export const Escrow = ({
             justifyContent={'center'}
             alignItems={'center'}
             backgroundColor={'#121212'}
+            position="relative"
         >
+            <Button
+                aria-label="Go back"
+                position="absolute"
+                top="16px"
+                right="16px"
+                onClick={() => router.back()}
+                variant="ghost"
+                color="white"
+                _hover={{ bg: 'whiteAlpha.200' }}
+                leftIcon={<IoArrowBack />}
+                size="md"
+                backgroundColor="#191919"
+                borderRadius="25px"
+            >
+                Back
+            </Button>
             {!isConnected ? (
                 <ModalCoverWalletConnect
                     title="Proceed to Escrow"
@@ -128,15 +146,28 @@ export const Escrow = ({
                     {order && (
                         <>
                             {isLoadingEscrowPayment && !escrowPayment ? (
-                                <Flex direction="column" align="center" justify="center" my={4}>
+                                <Flex
+                                    direction="column"
+                                    align="center"
+                                    justify="center"
+                                    my={4}
+                                >
                                     <Text mb={3}>Setting up escrow...</Text>
                                     <Text fontSize="sm" color="whiteAlpha.700">
-                                        This may take a minute while blockchain transactions confirm
+                                        This may take a minute while blockchain
+                                        transactions confirm
                                     </Text>
                                 </Flex>
                             ) : !escrowPayment && isFetching ? (
-                                <Flex direction="column" align="center" justify="center" my={4}>
-                                    <Text mb={3}>Checking for escrow payment...</Text>
+                                <Flex
+                                    direction="column"
+                                    align="center"
+                                    justify="center"
+                                    my={4}
+                                >
+                                    <Text mb={3}>
+                                        Checking for escrow payment...
+                                    </Text>
                                     <Text fontSize="sm" color="whiteAlpha.700">
                                         Waiting for blockchain confirmation
                                     </Text>
@@ -144,16 +175,39 @@ export const Escrow = ({
                             ) : (
                                 <>
                                     {!escrowPayment ? (
-                                        <Flex direction="column" align="center" justify="center" my={4} p={5}
-                                            borderWidth="1px" borderColor="whiteAlpha.300" borderRadius="md">
+                                        <Flex
+                                            direction="column"
+                                            align="center"
+                                            justify="center"
+                                            my={4}
+                                            p={5}
+                                            borderWidth="1px"
+                                            borderColor="whiteAlpha.300"
+                                            borderRadius="md"
+                                        >
                                             <Text mb={2}>
-                                                Order found {order.id.replace(/^order_/, '')}, waiting for escrow setup to complete
+                                                Order found{' '}
+                                                {order.id.replace(
+                                                    /^order_/,
+                                                    ''
+                                                )}
+                                                , waiting for escrow setup to
+                                                complete
                                             </Text>
-                                            <Text fontSize="sm" color="whiteAlpha.700">
-                                                Your payment is being processed. This may take a few moments.
+                                            <Text
+                                                fontSize="sm"
+                                                color="whiteAlpha.700"
+                                            >
+                                                Your payment is being processed.
+                                                This may take a few moments.
                                             </Text>
-                                            <Text fontSize="sm" color="whiteAlpha.700" mt={2}>
-                                                The page will automatically update when ready.
+                                            <Text
+                                                fontSize="sm"
+                                                color="whiteAlpha.700"
+                                                mt={2}
+                                            >
+                                                The page will automatically
+                                                update when ready.
                                             </Text>
                                         </Flex>
                                     ) : (
@@ -161,10 +215,14 @@ export const Escrow = ({
                                             {!escrowPayment.payerReleased && (
                                                 <ReleaseEscrowDialog
                                                     order={order}
-                                                    escrowPayment={escrowPayment}
+                                                    escrowPayment={
+                                                        escrowPayment
+                                                    }
                                                 />
                                             )}
-                                            <EscrowStatus payment={escrowPayment} />
+                                            <EscrowStatus
+                                                payment={escrowPayment}
+                                            />
                                         </>
                                     )}
                                 </>


### PR DESCRIPTION
Motivation

Once you get to the Release Escrow page, there’s no Back button to get back to where you were before. 

To Do: 

Add a ‘back’ navigation button or link or something 

Make it go to Manage Orders, preferably to the right tab (if easy) 