### PR TITLE
HAMSTR 583 filters on home and shop page are inconsistent

### DIFF
--- a/hamza-client/src/modules/products/components/buttons/category-button.tsx
+++ b/hamza-client/src/modules/products/components/buttons/category-button.tsx
@@ -14,30 +14,34 @@ const CategoryButton: React.FC<CategoryButtonProps> = ({
 }) => {
     const { selectedCategories, setSelectedCategories } = useUnifiedFilterStore();
 
-    const identifier = categoryName.trim().replace(/[\s_]+/g, '-').toLowerCase();
-    const isSelected = selectedCategories.includes(identifier);
+    const normalizeCategory = (name: string) => {
+        return name.trim().toLowerCase();
+    };
+
+    const normalizedCategory = normalizeCategory(categoryName);
+    const isSelected = selectedCategories.includes(normalizedCategory);
 
     const toggleCategorySelection = (category: string) => {
-        const normalizedCategory = category.toLowerCase();
+        const normalizedCat = normalizeCategory(category);
         const currentSelection = selectedCategories || [];
 
-        if (normalizedCategory === 'all') {
+        if (normalizedCat === 'all') {
             setSelectedCategories(['all']);
             return;
         }
 
-        if (currentSelection.includes(normalizedCategory)) {
-            const updated = currentSelection.filter((c) => c !== normalizedCategory);
+        if (currentSelection.includes(normalizedCat)) {
+            const updated = currentSelection.filter((c) => c !== normalizedCat);
             setSelectedCategories(updated.length ? updated : ['all']);
         } else {
             const updated = currentSelection.filter((c) => c !== 'all');
-            setSelectedCategories([...updated, normalizedCategory]);
+            setSelectedCategories([...updated, normalizedCat]);
         }
     };
     return (
         <Flex
             flexShrink={0}
-            onClick={() => toggleCategorySelection(identifier)}
+            onClick={() => toggleCategorySelection(categoryName)}
             borderColor={'#3E3E3E'}
             backgroundColor={isSelected ? 'white' : 'black'}
             display={'flex'}

--- a/hamza-client/src/modules/shop/components/desktop-side-filter/category-button.tsx
+++ b/hamza-client/src/modules/shop/components/desktop-side-filter/category-button.tsx
@@ -16,7 +16,7 @@ const CategoryButton: React.FC<CategoryButtonProps> = ({
     setSelectedCategories
 }) => {
     const normalizeCategory = (category: string) => {
-        return category.trim().replace(/[\s_]+/g, '-').toLowerCase();
+        return category.trim().toLowerCase();
     };
 
     const toggleCategorySelection = (category: string) => {

--- a/hamza-client/src/modules/shop/components/mobile-filter-modal/components/filter-modal.tsx
+++ b/hamza-client/src/modules/shop/components/mobile-filter-modal/components/filter-modal.tsx
@@ -51,6 +51,13 @@ const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose }) => {
     const [localRange, setLocalRange] = useState<RangeType>(range);
 
     useEffect(() => {
+        if (isOpen) {
+            setModalSelectedCategories(selectedCategories);
+            setLocalRange(range);
+        }
+    }, [isOpen, selectedCategories, range]);
+
+    useEffect(() => {
         setLocalRange(range);
     }, [range]);
 
@@ -176,8 +183,10 @@ const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose }) => {
                     </Button>
                     <Button
                         onClick={() => {
-                            if (selectedCategories.length === 0) {
+                            if (modalSelectedCategories.length === 0) {
                                 setSelectedCategories(['all']);
+                            } else {
+                                setSelectedCategories(modalSelectedCategories);
                             }
                             if (localRange[0] !== 0 || localRange[1] !== 350) {
                                 setRangeLower(localRange[0]);


### PR DESCRIPTION
**Changes:**

1. Fixed category normalization inconsistency - Standardized category name processing across all CategoryButton components (removed space-to-dash conversion)
2. Fixed shop page filter modal Apply button - Changed logic to check modal state instead of global state when applying filters
3. Resolved category selection issues - Categories with special characters (&) and spaces now work properly

**Test:**

1. Home page: Click filter bar categories that contain spaces or special characters - should show as selected and filter products
2. Shop page desktop: Test side filter + top bar with categories containing spaces/symbols - should work and actually filter products
3. Shop page mobile: Open filter modal, select categories with spaces/special characters, click "Apply Filters" - should work properly
4. Cross-verify: Test "Clear All"/"Reset" buttons work on all filter components
5. Filter accuracy: Verify products only appear in their correct category filters

**Test in both desktop and mobile views**