### PR TITLE
Hamstr 642 redo

### DIFF
--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -7,6 +7,7 @@ import { fetchCartForCheckout } from '@/app/[countryCode]/(checkout)/checkout/ut
 import { RainbowWrapper } from '@/app/components/providers/rainbowkit/rainbow-provider';
 import EmptyCart from '@/modules/cart/components/empty-cart';
 import { getHamzaCustomer } from '@/lib/server';
+import { fetchCartForCart } from '../../(main)/cart/utils/fetch-cart-for-cart';
 
 export const metadata: Metadata = {
     title: 'Checkout',
@@ -23,7 +24,7 @@ export default async function Checkout(params: any) {
         return notFound();
     }
 
-    const cart = await fetchCartForCheckout(cartId);
+    const cart = await fetchCartForCart();
 
     // get customer if logged in
     const customer = await getHamzaCustomer();

--- a/hamza-client/src/app/[countryCode]/(checkout)/checkout/utils/fetch-cart-for-checkout.ts
+++ b/hamza-client/src/app/[countryCode]/(checkout)/checkout/utils/fetch-cart-for-checkout.ts
@@ -35,8 +35,8 @@ export const fetchCartForCheckout = async (
     }
 
     // add default shipping method
-    if (!cart?.shipping_methods.length) {
-        const shippingMethod = await addDefaultShippingMethod(cartId);
+    if (!cart?.shipping_methods || !cart?.shipping_methods.length) {
+        const shippingMethod = await addDefaultShippingMethod(cart);
         if (shippingMethod) {
             cart = await retrieveCart(cartId);
         }

--- a/hamza-client/src/app/[countryCode]/(main)/cart/utils/fetch-cart-for-cart.ts
+++ b/hamza-client/src/app/[countryCode]/(main)/cart/utils/fetch-cart-for-cart.ts
@@ -2,6 +2,11 @@ import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
 import { LineItem, Cart, Store } from '@medusajs/medusa';
 import { CartWithCheckoutStep } from '@/types/global';
 import { getCheckoutStep } from '@lib/util/get-checkout-step';
+import {
+    addDefaultShippingMethod,
+    getShippingMethods,
+    setBestShippingAddress,
+} from '@/lib/server';
 
 type StoreWithItems = MedusaStore & {
     items: LineItem[];
@@ -13,15 +18,11 @@ type MedusaStore = Store & {
 
 export const fetchCartForCart =
     async (): Promise<CartWithCheckoutStep | null> => {
-        const cart = await retrieveCart().then(
-            (cart) => cart as CartWithCheckoutStep
-        );
+        let cart = await retrieveCart();
 
-        if (!cart) {
-            return null;
-        }
+        if (!cart) return null;
 
-        if (cart?.items?.length) {
+        if (cart.items.length) {
             const enrichedItems = await enrichLineItems(
                 cart.items,
                 cart.region_id

--- a/hamza-client/src/lib/util/get-product-price.ts
+++ b/hamza-client/src/lib/util/get-product-price.ts
@@ -98,6 +98,7 @@ export function getProductPrice({
     };
 }
 
+// formats crypto price (price in db) to human readable price
 export function formatCryptoPrice(
     amount: number,
     currencyCode: string = 'usdc',
@@ -140,6 +141,14 @@ export function formatCryptoPrice(
         console.error(e);
         return '0.00';
     }
+}
+
+export function formatHumanReadablePrice(
+    amount: number,
+    currencyCode: string = 'usdc'
+) {
+    const currencyPrecision = getCurrencyPrecision(currencyCode);
+    return amount.toFixed(currencyPrecision.display);
 }
 
 export function convertCryptoPrice(amount: number, from: string, to: string) {

--- a/hamza-client/src/lib/util/price-conversion.ts
+++ b/hamza-client/src/lib/util/price-conversion.ts
@@ -9,7 +9,7 @@ import { SeamlessCache } from './seamless-cache';
  * Example: convertPrice(1.05, 'usdc', 'eth')
  * Example: convertPrice(0.00348, 'eth', 'usdt')
  *
- * @param amount numeric amount, e.g. 0.0014855
+ * @param amount numeric amount, e.g. 0.0014855 - human readable price
  * @param from currency (lowercase), e.g. 'eth'
  * @param to currency (lowercase), e.g. 'usdc'
  */
@@ -20,7 +20,12 @@ export async function convertPrice(
 ): Promise<number> {
     from = from.trim().toLowerCase();
     to = to.trim().toLowerCase();
-    const key = `${from}-${to}`;
+
+    // if keys are the same, then just return whats in db for usdt-usdc conversion.
+    if (from === to) return amount;
+
+    let key = `${from}-${to}`;
+
     const output = await exchangeRateCache.retrieve();
 
     if (!output[key])

--- a/hamza-client/src/modules/cart/actions.ts
+++ b/hamza-client/src/modules/cart/actions.ts
@@ -6,12 +6,14 @@ import { revalidateTag } from 'next/cache';
 import { cookies } from 'next/headers';
 
 import {
+    addDefaultShippingMethod,
     addItem,
     createCart,
     createPaymentSessions,
     getCart,
     getProductsById,
     removeItem,
+    setBestShippingAddress,
     updateCart,
     updateItem,
 } from '@/lib/server';
@@ -65,7 +67,18 @@ export async function retrieveCart(
     }
 
     try {
+        const initialCart = await getCart(cartId).then((cart) => cart);
+
+        // set best shipping address
+        if (!initialCart.shipping_address_id) {
+            const address = await setBestShippingAddress(initialCart);
+        }
+
+        // add default shipping method
+        const shippingMethod = await addDefaultShippingMethod(initialCart);
+
         const cart = await getCart(cartId).then((cart) => cart);
+
         return cart;
     } catch (e) {
         console.error(e);

--- a/hamza-client/src/modules/cart/templates/cart-template.tsx
+++ b/hamza-client/src/modules/cart/templates/cart-template.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React, { useEffect } from 'react';
 import ItemsTemplate from './items-template';
 import Summary from './summary';
@@ -36,9 +37,10 @@ const CartTemplate = ({
         isLoading,
         isError,
     } = useQuery({
-        queryKey: ['cart'],
+        queryKey: ['cart', _cart.id],
         queryFn: fetchCartForCart,
-        staleTime: 1000 * 60 * 5,
+        staleTime: 0,
+        gcTime: 0,
         initialData: _cart,
     });
 

--- a/hamza-client/src/modules/checkout/components/addresses/index.tsx
+++ b/hamza-client/src/modules/checkout/components/addresses/index.tsx
@@ -23,16 +23,18 @@ const Addresses = ({
     cart: initialCart,
     customer,
 }: {
-    cart: Omit<Cart, 'refundable_amount' | 'refunded_total'> | null;
+    cart: CartWithCheckoutStep | null;
     customer: Omit<Customer, 'password_hash'> | null;
 }) => {
     const router = useRouter();
 
     // Use TanStack Query to fetch cart data
     const { data: cart } = useQuery({
-        queryKey: ['cart'],
+        queryKey: ['cart', initialCart?.id],
         queryFn: fetchCartForCart,
-        initialData: initialCart as CartWithCheckoutStep,
+        staleTime: 0,
+        gcTime: 0,
+        initialData: initialCart,
     });
 
     // Hooks to open and close address modal
@@ -70,32 +72,32 @@ const Addresses = ({
         onOpen();
     };
 
-    useEffect(() => {
-        const updateShippingMethod = async () => {
-            if (cart?.customer_id && cart?.shipping_address) {
-                console.log('Checking shipping method in address');
-                console.log('Shipping methods:', cart?.shipping_methods);
+    // useEffect(() => {
+    //     const updateShippingMethod = async () => {
+    //         if (cart?.customer_id && cart?.shipping_address) {
+    //             console.log('Checking shipping method in address');
+    //             console.log('Shipping methods:', cart?.shipping_methods);
 
-                if (!cart?.shipping_methods.length) {
-                    // If no shipping methods, add the default shipping method
-                    console.log('Adding default shipping method');
-                    axios.put(
-                        `${MEDUSA_SERVER_URL}/custom/cart/shipping`,
-                        {
-                            cart_id: cart.id,
-                        },
-                        {
-                            headers: {
-                                authorization: getClientCookie('_medusa_jwt'),
-                            },
-                        }
-                    );
-                }
-            }
-        };
+    //             if (!cart?.shipping_methods || !cart?.shipping_methods.length) {
+    //                 // If no shipping methods, add the default shipping method
+    //                 console.log('Adding default shipping method');
+    //                 axios.put(
+    //                     `${MEDUSA_SERVER_URL}/custom/cart/shipping`,
+    //                     {
+    //                         cart_id: cart.id,
+    //                     },
+    //                     {
+    //                         headers: {
+    //                             authorization: getClientCookie('_medusa_jwt'),
+    //                         },
+    //                     }
+    //                 );
+    //             }
+    //         }
+    //     };
 
-        updateShippingMethod();
-    }, [cart, router]);
+    //     updateShippingMethod();
+    // }, [cart, router]);
 
     return (
         <div>

--- a/hamza-client/src/modules/checkout/components/discount-code/index.tsx
+++ b/hamza-client/src/modules/checkout/components/discount-code/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React, { useMemo } from 'react';
 import { useFormState } from 'react-dom';
 

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { Cart } from '@medusajs/medusa';
 import {
     IWalletPaymentHandler,

--- a/hamza-client/src/modules/checkout/components/shipping/index.tsx
+++ b/hamza-client/src/modules/checkout/components/shipping/index.tsx
@@ -48,7 +48,7 @@ const Shipping: React.FC<ShippingProps> = ({
 
     const handleSubmit = () => {
         setIsLoading(true);
-        addDefaultShippingMethod(cart?.id).then(() => {
+        addDefaultShippingMethod(cart).then(() => {
             router.push(pathname + '?step=review', {
                 scroll: false,
             });

--- a/hamza-client/src/modules/checkout/templates/order-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/order-summary/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { Flex, Text, Spinner } from '@chakra-ui/react';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
 import React from 'react';

--- a/hamza-client/src/modules/checkout/templates/payment-summary/index.tsx
+++ b/hamza-client/src/modules/checkout/templates/payment-summary/index.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Flex, Text } from '@chakra-ui/react';
-import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
-import { LineItem } from '@medusajs/medusa';
 import CartTotals from '@modules/common/components/cart-totals';
 import DiscountCode from '@modules/checkout/components/discount-code';
 import PaymentButton from '@modules/checkout/components/payment/components/payment-button';
-import CheckoutTermsOfService from '@/modules/terms-of-service/templates/checkout-tos';
 import { CartWithCheckoutStep } from '@/types/global';
 
 const PaymentSummary = async ({ cart }: { cart: CartWithCheckoutStep }) => {

--- a/hamza-client/src/zustand/cart-store/cart-store.ts
+++ b/hamza-client/src/zustand/cart-store/cart-store.ts
@@ -3,17 +3,28 @@ import { create } from 'zustand';
 type State = {
     isUpdatingCart: boolean;
     isProcessingOrder: boolean;
+    cartUpdateEvents: Array<{ timestamp: number; value: boolean }>;
 };
 
 type Action = {
     setIsUpdatingCart: (updating: boolean) => void;
     setIsProcessingOrder: (processing: boolean) => void;
+    getCartUpdateEvents: () => Array<{ timestamp: number; value: boolean }>;
 };
 
-export const useCartStore = create<State & Action>((set) => ({
+export const useCartStore = create<State & Action>((set, get) => ({
     isUpdatingCart: false,
     isProcessingOrder: false,
-    setIsUpdatingCart: (updating: boolean) => set({ isUpdatingCart: updating }),
+    cartUpdateEvents: [],
+    setIsUpdatingCart: (updating: boolean) =>
+        set((state) => ({
+            isUpdatingCart: updating,
+            cartUpdateEvents: [
+                ...state.cartUpdateEvents,
+                { timestamp: Date.now(), value: updating },
+            ],
+        })),
     setIsProcessingOrder: (processing: boolean) =>
         set({ isProcessingOrder: processing }),
+    getCartUpdateEvents: () => get().cartUpdateEvents,
 }));


### PR DESCRIPTION
Problem:
- When switching currency, display flashes and incorrect conversion displays
- Conversion will switch in between to correct conversion, but not 100% of the time
- Increment/decrementing item quantity also creates incorrect display of conversion intermittently for the product
- The incorrect conversion will create numbers that are off by '000 (thousands) to the actual value

Solution:
- Refactored the cart-totals component completely, so each number that we require for calculation has a clear track of what 
currency that number was retrieved with.  
- Calculations will do conversions on the fly for the entire calculation model, so if eth, the math will all be based on the calculated eth price, if usdt... will be based on converted calculated usdt conversion price.
- As a result, sometime switching between currencies, there maybe slight variations.

**TEST:**
- add multiple items to cart, from different stores
- Go to /en/cart and review the numbers
- switch currencies and review the numbers
- Go to checkout
- switch currencies and review the numbers
- add a coupon code and see if its correct
- change item unit quantity to see if the converted price are correct

NOTE 1:  Also reworked the BTC conversion with the new calculations.
NOTE 2: Changing quantity still has a flash effect, where there is a loading icon, but it will display previous price, then suddenly switch.  Its a minor glitch and not easy to catch.  The problem is related to the storage of state in useCartStore.  Since it tracks a single event at a time, if there are multiple events, it will prematurely end the state change when others are still running.