### PR TITLE
HAMSTR-664: payment processing always show sepolia as payment chain

### DIFF
--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -74,7 +74,7 @@ const OrderProcessing = ({
 
     const blockchainData = _paymentData?.[0]?.blockchain_data;
 
-    const chainId = blockchainData?.chain_id;
+    const chainId = blockchainData?.payment_chain_id;
 
     const chainName = getChainNameFromId(chainId || 0);
 


### PR DESCRIPTION
Problem:
Chain being displayed is always incorrect.

Testing:
1. Choose a product to buy
2. Select any chain (apart from sepolia)
3. Click on Pay with External Wallet
4. Make sure the chain is the one you selected in (2)

Bonus:
5. Pay with that chain and make sure the payment goes through