### PR TITLE
HAMSTR-667: handling region countries regen when user logs in

### DIFF
--- a/hamza-client/src/modules/checkout/components/country-select/index.tsx
+++ b/hamza-client/src/modules/checkout/components/country-select/index.tsx
@@ -4,6 +4,7 @@ import NativeSelect, {
     NativeSelectProps,
 } from '@modules/common/components/native-select';
 import { Region } from '@medusajs/medusa';
+import { Text } from '@chakra-ui/react';
 
 const CountrySelect = forwardRef<
     HTMLSelectElement,
@@ -19,7 +20,7 @@ const CountrySelect = forwardRef<
     );
 
     const countryOptions = useMemo(() => {
-        if (!region) {
+        if (!region?.countries) {
             return [];
         }
 
@@ -29,21 +30,31 @@ const CountrySelect = forwardRef<
                 value: country.iso_2,
                 label: country.display_name,
             }));
-    }, [region]);
+    }, [region?.countries]);
 
     return (
-        <NativeSelect
-            ref={innerRef}
-            placeholder={placeholder}
-            defaultValue={defaultValue}
-            {...props}
-        >
-            {countryOptions.map(({ value, label }, index) => (
-                <option key={index} value={value}>
-                    {label}
-                </option>
-            ))}
-        </NativeSelect>
+        <>
+            {!region ||
+                (!region.countries && (
+                    <Text color="#ccc" fontSize="sm" py={4}>
+                        Countries loading...
+                    </Text>
+                ))}
+            {region?.countries && region.countries.length > 0 && (
+                <NativeSelect
+                    ref={innerRef}
+                    placeholder={placeholder}
+                    defaultValue={defaultValue}
+                    {...props}
+                >
+                    {countryOptions.map(({ value, label }, index) => (
+                        <option key={index} value={value}>
+                            {label}
+                        </option>
+                    ))}
+                </NativeSelect>
+            )}
+        </>
     );
 });
 


### PR DESCRIPTION
Problem:
When a user is not logged in -> finds item -> clicks "Buy Now" -> "Connect Wallet" -> "Add Shipping Address"

White Screen Error.

Fix:
The country select requires a region object which has a countries with undefined state until its loaded.  When no countries available, text will display "Countries loading...", until countries have completely loaded.

**TEST:**
1. Clear all cache data for your local/staging domain
2. When a user is not logged in -> finds item -> clicks "Buy Now" -> "Connect Wallet" -> "Add Shipping Address"
3. You should see "Countries loading..."
4. Then countries get populated

 