### PR TITLE
HAMSTR-658 SEO: Adding Product Schema to Product Details

### DIFF
--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -16,6 +16,8 @@ import { FaArrowLeftLong } from 'react-icons/fa6';
 import { useQuery } from '@tanstack/react-query';
 import { Spinner } from '@medusajs/icons';
 import { ProductSchema, Product } from '@/lib/schemas/product';
+import Head from 'next/head';
+import { formatCryptoPrice } from '@/lib/util/get-product-price';
 
 type ProductTemplateProps = {
     // product: PricedProduct;
@@ -108,125 +110,223 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
         enabled: !!product.id,
     });
 
+    /**
+     * Generates JSON-LD structured data for product pages
+     * Supports multiple cryptocurrencies (ETH, USDT, USDC)
+     * @returns {Object|null} Schema.org Product structured data
+     */
+    const generateProductJsonLd = () => {
+        if (!product) return null;
+
+        // Get all unique currencies from all variants
+        const allCurrencies = new Set<string>();
+        product.variants?.forEach(variant => {
+            variant.prices?.forEach(price => {
+                if (price.region_id === region.id || price.currency_code === region.currency_code) {
+                    allCurrencies.add(price.currency_code);
+                }
+            });
+        });
+
+        // Create one offer per currency (not per variant to avoid duplicates)
+        const offers = Array.from(allCurrencies).map((currency: string) => {
+            // Find any variant with this currency
+            const sampleVariant = product.variants?.find(variant =>
+                variant.prices?.some(price =>
+                    price.currency_code === currency &&
+                    (price.region_id === region.id || price.currency_code === region.currency_code)
+                )
+            );
+
+            if (!sampleVariant) return null;
+
+            const priceData = sampleVariant.prices?.find(price =>
+                price.currency_code === currency &&
+                (price.region_id === region.id || price.currency_code === region.currency_code)
+            );
+
+            if (!priceData) return null;
+
+            // Format price using existing crypto price formatter
+            const formattedPrice = formatCryptoPrice(
+                priceData.amount,
+                priceData.currency_code,
+                true
+            );
+
+            return {
+                "@type": "Offer",
+                "url": `https://hamza.market/${countryCode}/products/${product.handle}`,
+                "priceCurrency": priceData.currency_code.toUpperCase(),
+                "price": formattedPrice.toString(),
+                "availability": "https://schema.org/InStock",
+                "itemCondition": "https://schema.org/NewCondition",
+                "seller": {
+                    "@type": "Organization",
+                    "name": storeData?.name || "Hamza Market"
+                }
+            };
+        }).filter(Boolean);
+
+        const schema = {
+            "@context": "https://schema.org/",
+            "@type": "Product",
+            "name": product.title,
+            "description": product.description || "",
+            "image": product.images?.map(img => img.url) || [],
+            "sku": product.variants?.[0]?.sku || undefined,
+
+            // Add MPN if available in metadata
+            ...(product.metadata && typeof product.metadata === 'object' && 'mpn' in product.metadata && {
+                "mpn": product.metadata.mpn
+            }),
+
+            "brand": {
+                "@type": "Brand",
+                "name": storeData?.name || "Hamza Market"
+            },
+
+            // Use array if multiple currencies, single object if only one
+            "offers": offers.length === 1 ? offers[0] : offers,
+        };
+
+        console.log('SCHEMA FOR VALIDATION:', JSON.stringify(schema, null, 2));
+
+        return schema;
+    };
+
+
     return (
-        <Flex
-            flexDirection="column"
-            justifyContent={'center'}
-            alignItems={'center'}
-            maxW="1280px"
-            width={'100%'}
-            mx="auto"
-        >
-            <Flex
-                maxW="1280px"
-                width={'calc(100% - 2rem)'}
-                mx="rem"
-                flexDirection="column"
-            >
-                <Flex
-                    mt={{ base: '0', md: '1rem' }}
-                    mb="-1rem"
-                    height={'52px'}
-                    width="100%"
-                    flexDirection={'row'}
-                    display={{ base: 'none', md: 'flex' }}
-                >
-                    <LocalizedClientLink
-                        style={{
-                            display: 'flex',
-                            backgroundColor: '#121212',
-                            alignItems: 'center',
-                            padding: '0 16px',
-                            color: 'white',
-                            justifyContent: 'center',
-                            borderColor: '#3E3E3E',
-                            borderWidth: '1px',
-                            borderRadius: '16px',
-                            height: '52px',
+        <>
+            <Head>
+                {product && (
+                    <script
+                        type="application/ld+json"
+                        dangerouslySetInnerHTML={{
+                            __html: JSON.stringify(generateProductJsonLd(), null, 2)
                         }}
-                        className="ml-auto"
-                    >
-                        <Flex width={'30px'} height={'40px'}>
-                            <Flex
-                                width={'20px'}
-                                height={'20px'}
-                                alignSelf={'center'}
-                            >
-                                <FaArrowLeftLong
-                                    style={{
-                                        width: '100%',
-                                        height: '100%',
-                                        alignSelf: 'center',
-                                    }}
-                                />
-                            </Flex>
-                        </Flex>
-                        <Text>Back to results</Text>
-                    </LocalizedClientLink>
-                </Flex>
-                <Flex
-                    mt={{ base: '1rem', md: '2rem' }}
-                    mb={{ base: '-1rem', md: '0' }}
-                >
-                    <PreviewGallery
-                        handle={handle}
-                        selectedVariantImage={selectedVariantImage}
-                    />
-                </Flex>
-                <Flex
-                    maxWidth="1280px"
-                    width="100%"
-                    my="2rem"
-                    gap="26px"
-                    justifyContent="center"
-                    flexDirection={{ base: 'column', md: 'row' }}
-                >
-                    <Flex flex="1" order={{ base: 2, md: 1 }}>
-                        <Flex flexDirection="column">
-                            <ProductInfo handle={handle} />
-                            {/*<Box mt="1.5rem">*/}
-                            {/*    <Tweet*/}
-                            {/*        productHandle={product.handle as string}*/}
-                            {/*        isPurchased={false}*/}
-                            {/*    />*/}
-                            {/*</Box>*/}
-                        </Flex>
-                    </Flex>
-                    <Flex
-                        maxW={{ base: '100%', md: '504px' }}
-                        width="100%"
-                        flex="0 0 auto"
-                        justifyContent="center"
-                        order={{ base: 1, md: 2 }}
-                        alignSelf="flex-start"
-                    >
-                        <PreviewCheckout
-                            selectedVariantImage={selectedVariantImage}
-                            setSelectedVariantImage={setSelectedVariantImage}
-                            productId={product.id as string}
-                            handle={handle}
-                        />
-                    </Flex>
-                </Flex>
-                {isStoreLoading ? (
-                    <Spinner /> // Or some loading placeholder for StoreBanner
-                ) : isStoreError ? (
-                    <Text>Error loading store details</Text> // Handle error case gracefully
-                ) : (
-                    <StoreBanner
-                        storeHandle={storeData?.handle}
-                        storeName={storeData?.name}
-                        icon={storeData?.icon}
                     />
                 )}
-                <Divider
-                    color="#555555"
-                    display={{ base: 'block', md: 'none' }}
-                    mt="2rem"
-                />
-                <ProductReview />
+            </Head>
+            <Flex
+                flexDirection="column"
+                justifyContent={'center'}
+                alignItems={'center'}
+                maxW="1280px"
+                width={'100%'}
+                mx="auto"
+            >
+                <Flex
+                    maxW="1280px"
+                    width={'calc(100% - 2rem)'}
+                    mx="rem"
+                    flexDirection="column"
+                >
+                    <Flex
+                        mt={{ base: '0', md: '1rem' }}
+                        mb="-1rem"
+                        height={'52px'}
+                        width="100%"
+                        flexDirection={'row'}
+                        display={{ base: 'none', md: 'flex' }}
+                    >
+                        <LocalizedClientLink
+                            style={{
+                                display: 'flex',
+                                backgroundColor: '#121212',
+                                alignItems: 'center',
+                                padding: '0 16px',
+                                color: 'white',
+                                justifyContent: 'center',
+                                borderColor: '#3E3E3E',
+                                borderWidth: '1px',
+                                borderRadius: '16px',
+                                height: '52px',
+                            }}
+                            className="ml-auto"
+                        >
+                            <Flex width={'30px'} height={'40px'}>
+                                <Flex
+                                    width={'20px'}
+                                    height={'20px'}
+                                    alignSelf={'center'}
+                                >
+                                    <FaArrowLeftLong
+                                        style={{
+                                            width: '100%',
+                                            height: '100%',
+                                            alignSelf: 'center',
+                                        }}
+                                    />
+                                </Flex>
+                            </Flex>
+                            <Text>Back to results</Text>
+                        </LocalizedClientLink>
+                    </Flex>
+                    <Flex
+                        mt={{ base: '1rem', md: '2rem' }}
+                        mb={{ base: '-1rem', md: '0' }}
+                    >
+                        <PreviewGallery
+                            handle={handle}
+                            selectedVariantImage={selectedVariantImage}
+                        />
+                    </Flex>
+                    <Flex
+                        maxWidth="1280px"
+                        width="100%"
+                        my="2rem"
+                        gap="26px"
+                        justifyContent="center"
+                        flexDirection={{ base: 'column', md: 'row' }}
+                    >
+                        <Flex flex="1" order={{ base: 2, md: 1 }}>
+                            <Flex flexDirection="column">
+                                <ProductInfo handle={handle} />
+                                {/*<Box mt="1.5rem">*/}
+                                {/*    <Tweet*/}
+                                {/*        productHandle={product.handle as string}*/}
+                                {/*        isPurchased={false}*/}
+                                {/*    />*/}
+                                {/*</Box>*/}
+                            </Flex>
+                        </Flex>
+                        <Flex
+                            maxW={{ base: '100%', md: '504px' }}
+                            width="100%"
+                            flex="0 0 auto"
+                            justifyContent="center"
+                            order={{ base: 1, md: 2 }}
+                            alignSelf="flex-start"
+                        >
+                            <PreviewCheckout
+                                selectedVariantImage={selectedVariantImage}
+                                setSelectedVariantImage={setSelectedVariantImage}
+                                productId={product.id as string}
+                                handle={handle}
+                            />
+                        </Flex>
+                    </Flex>
+                    {isStoreLoading ? (
+                        <Spinner /> // Or some loading placeholder for StoreBanner
+                    ) : isStoreError ? (
+                        <Text>Error loading store details</Text> // Handle error case gracefully
+                    ) : (
+                        <StoreBanner
+                            storeHandle={storeData?.handle}
+                            storeName={storeData?.name}
+                            icon={storeData?.icon}
+                        />
+                    )}
+                    <Divider
+                        color="#555555"
+                        display={{ base: 'block', md: 'none' }}
+                        mt="2rem"
+                    />
+                    <ProductReview />
+                </Flex>
             </Flex>
-        </Flex>
+        </>
     );
 };
 

--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -119,8 +119,6 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
     const generateProductJsonLd = () => {
         if (!product) return null;
 
-        console.log('product for schema:', product);
-
         /**
          * Helper function to strip HTML tags from description
          */

--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -16,7 +16,6 @@ import { FaArrowLeftLong } from 'react-icons/fa6';
 import { useQuery } from '@tanstack/react-query';
 import { Spinner } from '@medusajs/icons';
 import { ProductSchema, Product } from '@/lib/schemas/product';
-import Head from 'next/head';
 import { formatCryptoPrice } from '@/lib/util/get-product-price';
 
 type ProductTemplateProps = {
@@ -194,7 +193,10 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
                 "itemCondition": "https://schema.org/NewCondition",
                 "seller": {
                     "@type": "Organization",
-                    "name": storeData?.name || "Hamza Market"
+                    "name": storeData?.name || "Hamza Market",
+                    "url": storeData?.handle
+                        ? `https://hamza.market/${countryCode}/store/${storeData.handle}`
+                        : "https://hamza.market"
                 }
             };
         }).filter(Boolean);
@@ -209,7 +211,10 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
 
             "brand": {
                 "@type": "Brand",
-                "name": storeData?.name || "Hamza Market"
+                "name": storeData?.name || "Hamza Market",
+                "url": storeData?.handle
+                    ? `https://hamza.market/${countryCode}/store/${storeData.handle}`
+                    : "https://hamza.market"
             },
 
             "offers": offers,
@@ -293,136 +298,132 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
 
 
     return (
-        <>
-            <Head>
-                {product && (
-                    <script
-                        type="application/ld+json"
-                        dangerouslySetInnerHTML={{
-                            __html: JSON.stringify(generateProductJsonLd(), null, 2)
-                        }}
-                    />
-                )}
-            </Head>
+        <Flex
+            flexDirection="column"
+            justifyContent={'center'}
+            alignItems={'center'}
+            maxW="1280px"
+            width={'100%'}
+            mx="auto"
+        >
+            {product && (
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify(generateProductJsonLd(), null, 2)
+                    }}
+                />
+            )}
             <Flex
-                flexDirection="column"
-                justifyContent={'center'}
-                alignItems={'center'}
                 maxW="1280px"
-                width={'100%'}
-                mx="auto"
+                width={'calc(100% - 2rem)'}
+                mx="rem"
+                flexDirection="column"
             >
                 <Flex
-                    maxW="1280px"
-                    width={'calc(100% - 2rem)'}
-                    mx="rem"
-                    flexDirection="column"
+                    mt={{ base: '0', md: '1rem' }}
+                    mb="-1rem"
+                    height={'52px'}
+                    width="100%"
+                    flexDirection={'row'}
+                    display={{ base: 'none', md: 'flex' }}
                 >
-                    <Flex
-                        mt={{ base: '0', md: '1rem' }}
-                        mb="-1rem"
-                        height={'52px'}
-                        width="100%"
-                        flexDirection={'row'}
-                        display={{ base: 'none', md: 'flex' }}
+                    <LocalizedClientLink
+                        style={{
+                            display: 'flex',
+                            backgroundColor: '#121212',
+                            alignItems: 'center',
+                            padding: '0 16px',
+                            color: 'white',
+                            justifyContent: 'center',
+                            borderColor: '#3E3E3E',
+                            borderWidth: '1px',
+                            borderRadius: '16px',
+                            height: '52px',
+                        }}
+                        className="ml-auto"
                     >
-                        <LocalizedClientLink
-                            style={{
-                                display: 'flex',
-                                backgroundColor: '#121212',
-                                alignItems: 'center',
-                                padding: '0 16px',
-                                color: 'white',
-                                justifyContent: 'center',
-                                borderColor: '#3E3E3E',
-                                borderWidth: '1px',
-                                borderRadius: '16px',
-                                height: '52px',
-                            }}
-                            className="ml-auto"
-                        >
-                            <Flex width={'30px'} height={'40px'}>
-                                <Flex
-                                    width={'20px'}
-                                    height={'20px'}
-                                    alignSelf={'center'}
-                                >
-                                    <FaArrowLeftLong
-                                        style={{
-                                            width: '100%',
-                                            height: '100%',
-                                            alignSelf: 'center',
-                                        }}
-                                    />
-                                </Flex>
-                            </Flex>
-                            <Text>Back to results</Text>
-                        </LocalizedClientLink>
-                    </Flex>
-                    <Flex
-                        mt={{ base: '1rem', md: '2rem' }}
-                        mb={{ base: '-1rem', md: '0' }}
-                    >
-                        <PreviewGallery
-                            handle={handle}
-                            selectedVariantImage={selectedVariantImage}
-                        />
-                    </Flex>
-                    <Flex
-                        maxWidth="1280px"
-                        width="100%"
-                        my="2rem"
-                        gap="26px"
-                        justifyContent="center"
-                        flexDirection={{ base: 'column', md: 'row' }}
-                    >
-                        <Flex flex="1" order={{ base: 2, md: 1 }}>
-                            <Flex flexDirection="column">
-                                <ProductInfo handle={handle} />
-                                {/*<Box mt="1.5rem">*/}
-                                {/*    <Tweet*/}
-                                {/*        productHandle={product.handle as string}*/}
-                                {/*        isPurchased={false}*/}
-                                {/*    />*/}
-                                {/*</Box>*/}
+                        <Flex width={'30px'} height={'40px'}>
+                            <Flex
+                                width={'20px'}
+                                height={'20px'}
+                                alignSelf={'center'}
+                            >
+                                <FaArrowLeftLong
+                                    style={{
+                                        width: '100%',
+                                        height: '100%',
+                                        alignSelf: 'center',
+                                    }}
+                                />
                             </Flex>
                         </Flex>
-                        <Flex
-                            maxW={{ base: '100%', md: '504px' }}
-                            width="100%"
-                            flex="0 0 auto"
-                            justifyContent="center"
-                            order={{ base: 1, md: 2 }}
-                            alignSelf="flex-start"
-                        >
-                            <PreviewCheckout
-                                selectedVariantImage={selectedVariantImage}
-                                setSelectedVariantImage={setSelectedVariantImage}
-                                productId={product.id as string}
-                                handle={handle}
-                            />
-                        </Flex>
-                    </Flex>
-                    {isStoreLoading ? (
-                        <Spinner /> // Or some loading placeholder for StoreBanner
-                    ) : isStoreError ? (
-                        <Text>Error loading store details</Text> // Handle error case gracefully
-                    ) : (
-                        <StoreBanner
-                            storeHandle={storeData?.handle}
-                            storeName={storeData?.name}
-                            icon={storeData?.icon}
-                        />
-                    )}
-                    <Divider
-                        color="#555555"
-                        display={{ base: 'block', md: 'none' }}
-                        mt="2rem"
-                    />
-                    <ProductReview />
+                        <Text>Back to results</Text>
+                    </LocalizedClientLink>
                 </Flex>
+                <Flex
+                    mt={{ base: '1rem', md: '2rem' }}
+                    mb={{ base: '-1rem', md: '0' }}
+                >
+                    <PreviewGallery
+                        handle={handle}
+                        selectedVariantImage={selectedVariantImage}
+                    />
+                </Flex>
+                <Flex
+                    maxWidth="1280px"
+                    width="100%"
+                    my="2rem"
+                    gap="26px"
+                    justifyContent="center"
+                    flexDirection={{ base: 'column', md: 'row' }}
+                >
+                    <Flex flex="1" order={{ base: 2, md: 1 }}>
+                        <Flex flexDirection="column">
+                            <ProductInfo handle={handle} />
+                            {/*<Box mt="1.5rem">*/}
+                            {/*    <Tweet*/}
+                            {/*        productHandle={product.handle as string}*/}
+                            {/*        isPurchased={false}*/}
+                            {/*    />*/}
+                            {/*</Box>*/}
+                        </Flex>
+                    </Flex>
+                    <Flex
+                        maxW={{ base: '100%', md: '504px' }}
+                        width="100%"
+                        flex="0 0 auto"
+                        justifyContent="center"
+                        order={{ base: 1, md: 2 }}
+                        alignSelf="flex-start"
+                    >
+                        <PreviewCheckout
+                            selectedVariantImage={selectedVariantImage}
+                            setSelectedVariantImage={setSelectedVariantImage}
+                            productId={product.id as string}
+                            handle={handle}
+                        />
+                    </Flex>
+                </Flex>
+                {isStoreLoading ? (
+                    <Spinner /> // Or some loading placeholder for StoreBanner
+                ) : isStoreError ? (
+                    <Text>Error loading store details</Text> // Handle error case gracefully
+                ) : (
+                    <StoreBanner
+                        storeHandle={storeData?.handle}
+                        storeName={storeData?.name}
+                        icon={storeData?.icon}
+                    />
+                )}
+                <Divider
+                    color="#555555"
+                    display={{ base: 'block', md: 'none' }}
+                    mt="2rem"
+                />
+                <ProductReview />
             </Flex>
-        </>
+        </Flex>
     );
 };
 

--- a/hamza-client/src/modules/products/templates/index.tsx
+++ b/hamza-client/src/modules/products/templates/index.tsx
@@ -113,53 +113,86 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
     /**
      * Generates JSON-LD structured data for product pages
      * Supports multiple cryptocurrencies (ETH, USDT, USDC)
+     * TypeScript-safe with comprehensive error handling
      * @returns {Object|null} Schema.org Product structured data
      */
     const generateProductJsonLd = () => {
         if (!product) return null;
 
+        console.log('product for schema:', product);
+
+        /**
+         * Helper function to strip HTML tags from description
+         */
+        const stripHtmlTags = (html: string) => {
+            return html.replace(/<[^>]*>/g, '').trim();
+        };
+
+        /**
+         * Determine product availability based on inventory
+         */
+        const getAvailability = (variant: any) => {
+            if (variant.inventory_quantity > 0) {
+                return "https://schema.org/InStock";
+            } else if (variant.allow_backorder) {
+                return "https://schema.org/BackOrder";
+            } else {
+                return "https://schema.org/OutOfStock";
+            }
+        };
+
+        /**
+         * TypeScript-safe way to access product properties
+         */
+        const safeProductAccess = (product: any) => {
+            return {
+                collection: product?.collection || null,
+                variants: product?.variants || [],
+                images: product?.images || [],
+                metadata: product?.metadata || null,
+                weight: product?.weight || null,
+                length: product?.length || null,
+                width: product?.width || null,
+                height: product?.height || null,
+            };
+        };
+
+        const safeProduct = safeProductAccess(product);
+
         // Get all unique currencies from all variants
         const allCurrencies = new Set<string>();
-        product.variants?.forEach(variant => {
-            variant.prices?.forEach(price => {
-                if (price.region_id === region.id || price.currency_code === region.currency_code) {
-                    allCurrencies.add(price.currency_code);
-                }
+        safeProduct.variants.forEach((variant: any) => {
+            variant.prices?.forEach((price: any) => {
+                allCurrencies.add(price.currency_code);
             });
         });
 
-        // Create one offer per currency (not per variant to avoid duplicates)
+        // Create offers for each currency
         const offers = Array.from(allCurrencies).map((currency: string) => {
-            // Find any variant with this currency
-            const sampleVariant = product.variants?.find(variant =>
-                variant.prices?.some(price =>
-                    price.currency_code === currency &&
-                    (price.region_id === region.id || price.currency_code === region.currency_code)
-                )
+            const sampleVariant = safeProduct.variants.find((variant: any) =>
+                variant.prices?.some((price: any) => price.currency_code === currency)
             );
 
             if (!sampleVariant) return null;
 
-            const priceData = sampleVariant.prices?.find(price =>
-                price.currency_code === currency &&
-                (price.region_id === region.id || price.currency_code === region.currency_code)
+            const priceData = sampleVariant.prices?.find((price: any) =>
+                price.currency_code === currency
             );
 
             if (!priceData) return null;
 
-            // Format price using existing crypto price formatter
             const formattedPrice = formatCryptoPrice(
                 priceData.amount,
                 priceData.currency_code,
                 true
-            );
+            ).toString();
 
             return {
                 "@type": "Offer",
                 "url": `https://hamza.market/${countryCode}/products/${product.handle}`,
                 "priceCurrency": priceData.currency_code.toUpperCase(),
-                "price": formattedPrice.toString(),
-                "availability": "https://schema.org/InStock",
+                "price": formattedPrice,
+                "availability": getAvailability(sampleVariant),
                 "itemCondition": "https://schema.org/NewCondition",
                 "seller": {
                     "@type": "Organization",
@@ -168,29 +201,94 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
             };
         }).filter(Boolean);
 
-        const schema = {
+        // Base schema object
+        const schema: any = {
             "@context": "https://schema.org/",
             "@type": "Product",
             "name": product.title,
-            "description": product.description || "",
-            "image": product.images?.map(img => img.url) || [],
-            "sku": product.variants?.[0]?.sku || undefined,
-
-            // Add MPN if available in metadata
-            ...(product.metadata && typeof product.metadata === 'object' && 'mpn' in product.metadata && {
-                "mpn": product.metadata.mpn
-            }),
+            "description": product.description ? stripHtmlTags(product.description) : "",
+            "image": safeProduct.images.map((img: any) => img.url),
 
             "brand": {
                 "@type": "Brand",
                 "name": storeData?.name || "Hamza Market"
             },
 
-            // Use array if multiple currencies, single object if only one
-            "offers": offers.length === 1 ? offers[0] : offers,
+            "offers": offers,
         };
 
-        console.log('SCHEMA FOR VALIDATION:', JSON.stringify(schema, null, 2));
+        // Add SKU if available
+        if (safeProduct.variants[0]?.sku) {
+            schema.sku = safeProduct.variants[0].sku;
+        }
+
+        // Add MPN from metadata if available
+        if (safeProduct.metadata &&
+            typeof safeProduct.metadata === 'object' &&
+            'mpn' in safeProduct.metadata &&
+            safeProduct.metadata.mpn) {
+            schema.mpn = safeProduct.metadata.mpn;
+        }
+
+        // Add GTINs if available
+        if (safeProduct.variants[0]?.upc) {
+            schema.gtin12 = safeProduct.variants[0].upc;
+        }
+        if (safeProduct.variants[0]?.ean) {
+            schema.gtin13 = safeProduct.variants[0].ean;
+        }
+
+        // Add weight if available
+        if (safeProduct.weight) {
+            schema.weight = {
+                "@type": "QuantitativeValue",
+                "value": safeProduct.weight,
+                "unitCode": "GRM"
+            };
+        }
+
+        // Add product category if available 
+        if (safeProduct.collection?.title) {
+            schema.category = safeProduct.collection.title;
+        }
+
+        // Add dimensions if available
+        const hasAnyDimension = safeProduct.length || safeProduct.width || safeProduct.height;
+        if (hasAnyDimension) {
+            schema.additionalProperty = [];
+
+            if (safeProduct.length) {
+                schema.additionalProperty.push({
+                    "@type": "PropertyValue",
+                    "name": "Length",
+                    "value": safeProduct.length,
+                    "unitCode": "CMT" 
+                });
+            }
+
+            if (safeProduct.width) {
+                schema.additionalProperty.push({
+                    "@type": "PropertyValue",
+                    "name": "Width",
+                    "value": safeProduct.width,
+                    "unitCode": "CMT"
+                });
+            }
+
+            if (safeProduct.height) {
+                schema.additionalProperty.push({
+                    "@type": "PropertyValue",
+                    "name": "Height",
+                    "value": safeProduct.height,
+                    "unitCode": "CMT"
+                });
+            }
+        }
+
+        // Add product URL
+        schema.url = `https://hamza.market/${countryCode}/products/${product.handle}`;
+
+        console.log('FINAL ENHANCED SCHEMA:', JSON.stringify(schema, null, 2));
 
         return schema;
     };


### PR DESCRIPTION
In product details page add a product schema

Changes : 

1. Add generateProductJsonLd() function to generate JSON-LD structured data for products

Tests : 

1. Navigate to any product details page
2. Copy the JSON from "FINAL ENHANCED SCHEMA" in console logs
3. Paste at https://validator.schema.org/
4. Verify 0 errors and 0 warnings in validation results
