### PR TITLE
HAMSL-508 : Secondary Images for Products not showing on Site

### DIFF
--- a/hamza-client/src/modules/products/components/product-preview/components/image-gallery/image-display/preview-gallery.tsx
+++ b/hamza-client/src/modules/products/components/product-preview/components/image-gallery/image-display/preview-gallery.tsx
@@ -39,16 +39,24 @@ const PreviewGallery: React.FC<PreviewGalleryProps> = ({
     const [selectedImageIndex, setSelectedImageIndex] = useState<number>(0);
 
     useEffect(() => {
-        // Construct the initial images array from product data
-        let newImages = product?.images?.map((img: ImageType) => img.url) || [];
+        // Get all product gallery images
+        let galleryImages = product?.images?.map((img: ImageType) => img.url) || [];
 
-        // Check if a selected variant image is provided and is different from the main image
-        if (selectedVariantImage && selectedVariantImage !== newImages[0]) {
-            // Place the selected variant image at the start of the array
-            newImages = [
-                selectedVariantImage,
-                ...newImages.filter((img: string, index: number) => index > 0),
-            ];
+        let newImages = [...galleryImages]; // Start with all gallery images
+
+        // If we have a selected variant image
+        if (selectedVariantImage) {
+            // Check if the variant image is already in the gallery
+            const variantImageIndex = galleryImages.indexOf(selectedVariantImage);
+
+            if (variantImageIndex === -1) {
+                newImages = [selectedVariantImage, ...galleryImages];
+            } else if (variantImageIndex > 0) {
+                newImages = [
+                    selectedVariantImage,
+                    ...galleryImages.filter((img, index) => index !== variantImageIndex)
+                ];
+            }
         }
 
         // Update the images state


### PR DESCRIPTION
**Changes**

1. Fixed image array logic in PreviewGallery component
2. Prevent gallery images from being removed when variant image is selected
3. Preserve all product images from admin panel

**Tests**

1. In the seller side, add new product with multiple images
2. Verify in the storefront all gallery images show up
