### PR TITLE
HAMSTR-677 - incorrect currency icon in order processing

### DIFF
--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -1068,22 +1068,15 @@ const OrderProcessing = ({
                                     </Text>
                                     <Flex gap={2}>
                                         <Text color="white">Total Amount:</Text>
-                                        {paywith === 'bitcoin' ? (
-                                            <FaBitcoin
-                                                size={24}
-                                                color="#F7931A"
-                                            />
-                                        ) : (
-                                            <Image
-                                                className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                                src={
-                                                    currencyIcons[
-                                                        currencyCode ?? 'usdc'
-                                                    ]
-                                                }
-                                                alt={currencyCode ?? 'usdc'}
-                                            />
-                                        )}
+                                        <Image
+                                            className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
+                                            src={
+                                                currencyIcons[
+                                                    currencyCode ?? 'usdc'
+                                                ]
+                                            }
+                                            alt={currencyCode ?? 'usdc'}
+                                        />
                                         <Text ml="0.4rem" color="white">
                                             {formatCryptoPrice(
                                                 paymentTotal ?? 0,


### PR DESCRIPTION
Problem:
At the bottom, Total Amount is displayed in the default currency.  When the default currency is ETH, and you are paying by bitcoin, the icon at the bottom is displaying BTC, not ETH.

**Test:**
1. Go to checkout, make sure you are paying in ETH
2. Select pay with bitcoin
3. In order processing screen, look at the bottom, Total Amount, the icon displayed should be ETH.
