### PR TITLE
HAMSTR-660 - Organization schema on homepage

### DIFF
--- a/hamza-client/src/app/components/schema-markup.tsx
+++ b/hamza-client/src/app/components/schema-markup.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Script from 'next/script';
+
+export default function SchemaMarkup() {
+    const pathname = usePathname();
+    const isRootPath = pathname === '/en';
+
+    if (!isRootPath) return null;
+
+    return (
+        <Script
+            id="schema-markup"
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify({
+                    '@context': 'https://schema.org',
+                    '@type': 'Organization',
+                    name: 'Hamza Market',
+                    url: 'https://hamza.market',
+                    contactPoint: [
+                        {
+                            '@type': 'ContactPoint',
+                            email: 'contact@hamzamarket.com',
+                            contactType: 'Customer Support',
+                        },
+                    ],
+                    sameAs: ['https://discord.com/invite/JRxzu5ZYjp'],
+                }),
+            }}
+        />
+    );
+}

--- a/hamza-client/src/app/layout.tsx
+++ b/hamza-client/src/app/layout.tsx
@@ -5,18 +5,16 @@ import { cookies } from 'next/headers';
 
 const BASE_URL =
     process.env.NEXT_PUBLIC_MEDUSA_CLIENT_URL || 'https://localhost:8000';
-import MedusaProvider from '@/components/providers/medusa/medusa-provider';
 import { RainbowWrapper } from '@/components/providers/rainbowkit/rainbow-provider';
 import { ChakraProvider } from '@chakra-ui/react';
 import theme from '../styles/chakra-theme';
 import { Toaster } from 'react-hot-toast';
 import { Sora } from 'next/font/google';
-import Script from 'next/script';
 import FreeScoutWidget from './components/scripts/chat-widget';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import T5QueryProvider from '@/components/providers/t5-query-provider';
+import SchemaMarkup from './components/schema-markup';
 
-// import { GoogleTagManager } from '@next/third-parties/google';
 export const metadata: Metadata = {
     metadataBase: new URL(BASE_URL),
 };
@@ -33,6 +31,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
     return (
         <html lang="en" data-mode="dark">
             <head>
+                <SchemaMarkup />
                 {/* Google Tag Manager Script */}
                 {/* <Script
                     id="gtm-script"


### PR DESCRIPTION
Adding Organization schema on homepage

Implementation:
- added organization schema for homepage only (root for site)

**Test:**
- Visit the homepage
- Make sure the Organization schema is functional
- Go to other pages, and make sure the schema doesn't display in other places
