### PR TITLE
HAMSTR-684 bitcoin payments don't show as bitcoin payments

### DIFF
--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -18,6 +18,7 @@ import { formatCryptoPrice } from '@/lib/util/get-product-price';
 import { EscrowStatusString } from '@/lib/server/enums';
 import currencyIcons from '@/images/currencies/crypto-currencies';
 import LocalizedClientLink from '@modules/common/components/localized-client-link';
+import { FaBitcoin } from 'react-icons/fa';
 
 // Define types for the component
 interface LineItem {
@@ -53,6 +54,12 @@ interface ExtendedOrder {
     total?: number;
     payments?: Array<{
         amount: number;
+        metadata?: {
+            chainType?: string;
+            chainId?: string;
+            currency?: string;
+            amount?: string;
+        };
     }>;
     discounts?: Array<{
         code: string;
@@ -73,6 +80,7 @@ interface OrderConfirmedProps {
 }
 
 const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
+
     // calculate totals
     const cartOrderTotal = orders.reduce(
         (total: number, order: ExtendedOrder) =>
@@ -120,6 +128,26 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
     ).join(', ');
 
     const currencyCode = orders[0].currency_code;
+
+    const getBitcoinPaymentInfo = () => {
+        let hasBitcoinPayment = false;
+        let bitcoinAmount: string = '';
+
+        orders.forEach(order => {
+            if (order.payments) {
+                order.payments.forEach(payment => {
+                    if (payment.metadata?.currency === 'btc') {
+                        hasBitcoinPayment = true;
+                        bitcoinAmount = payment.metadata.amount ?? '';
+                    }
+                });
+            }
+        });
+
+        return { hasBitcoinPayment, bitcoinAmount };
+    };
+
+    const { hasBitcoinPayment, bitcoinAmount } = getBitcoinPaymentInfo();
 
     return (
         <Flex
@@ -569,13 +597,17 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                     >
                         <Text>Total Amount Paid:</Text>
                         <HStack>
-                            <Image
-                                className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
-                                src={currencyIcons[currencyCode ?? 'usdc']}
-                                alt={currencyCode ?? 'usdc'}
-                            />
+                            {hasBitcoinPayment ? (
+                                <Icon as={FaBitcoin} boxSize="18px" color="#F7931A" />
+                            ) : (
+                                <Image
+                                    className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
+                                    src={currencyIcons[currencyCode ?? 'usdc']}
+                                    alt={currencyCode ?? 'usdc'}
+                                />
+                            )}
                             <Text>
-                                {formatCryptoPrice(totalPaid, currencyCode)}
+                                {hasBitcoinPayment ? bitcoinAmount : formatCryptoPrice(totalPaid, currencyCode)}
                             </Text>
                         </HStack>
                     </Flex>

--- a/hamza-client/src/modules/order/components/order-details.tsx
+++ b/hamza-client/src/modules/order/components/order-details.tsx
@@ -38,7 +38,7 @@ interface Order {
     tracking_number?: string;
     items: OrderItem[] | any;
     store: OrderStore;
-    payments: Payment[];
+    payments?: Payment[];
     external_metadata?: {
         tracking?: {
             data?: {
@@ -72,7 +72,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
         let bitcoinAmount: string = '';
 
         if (order.payments) {
-            order.payments.forEach(payment => {
+            order.payments.forEach((payment) => {
                 if (payment.metadata?.currency === 'btc') {
                     hasBitcoinPayment = true;
                     bitcoinAmount = payment.metadata.amount ?? '';
@@ -98,7 +98,11 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
             : orderShippingTotal;
 
     // Helper function to render amount with appropriate icon
-    const renderAmountWithIcon = (amount: number, label: string, showMinus = false) => (
+    const renderAmountWithIcon = (
+        amount: number,
+        label: string,
+        showMinus = false
+    ) => (
         <Flex fontSize="md" alignItems="center" gap={2}>
             <Text fontWeight="bold">{label}:</Text>
             {showMinus && <Text>-</Text>}
@@ -106,7 +110,10 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
                 <Icon as={FaBitcoin} boxSize="16px" color="#F7931A" />
             ) : (
                 <Image
-                    src={currencyIcons[currencyCode.toLowerCase()] ?? currencyIcons['usdc']}
+                    src={
+                        currencyIcons[currencyCode.toLowerCase()] ??
+                        currencyIcons['usdc']
+                    }
                     alt={currencyCode.toUpperCase()}
                     width={16}
                     height={16}
@@ -115,8 +122,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
             <Text>
                 {hasBitcoinPayment
                     ? bitcoinAmount
-                    : `${formatCryptoPrice(amount, currencyCode)} ${upperCase(currencyCode)}`
-                }
+                    : `${formatCryptoPrice(amount, currencyCode)} ${upperCase(currencyCode)}`}
             </Text>
         </Flex>
     );
@@ -132,36 +138,41 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
                         </Text>
                     )}
 
-                    {renderAmountWithIcon(numericSubTotal, "Subtotal")}
+                    {renderAmountWithIcon(numericSubTotal, 'Subtotal')}
 
                     {numericDiscountTotal > 0 &&
-                        renderAmountWithIcon(numericDiscountTotal, "Order Discount Total", true)
-                    }
+                        renderAmountWithIcon(
+                            numericDiscountTotal,
+                            'Order Discount Total',
+                            true
+                        )}
 
                     {numericShippingTotal > 0 &&
-                        renderAmountWithIcon(numericShippingTotal, "Order Shipping Cost")
-                    }
+                        renderAmountWithIcon(
+                            numericShippingTotal,
+                            'Order Shipping Cost'
+                        )}
 
                     {order.external_metadata?.tracking?.data?.soOrderInfo
                         ?.createTime && (
-                            <Flex alignItems="center">
-                                <Text fontWeight="bold" mr={2}>
-                                    Shipped on Date:
-                                </Text>
-                                <Text>
-                                    {new Date(
-                                        order.external_metadata.tracking.data.soOrderInfo.createTime
-                                    ).toLocaleString(undefined, {
-                                        year: 'numeric',
-                                        month: 'long',
-                                        day: 'numeric',
-                                        hour: '2-digit',
-                                        minute: '2-digit',
-                                        second: '2-digit',
-                                    })}
-                                </Text>
-                            </Flex>
-                        )}
+                        <Flex alignItems="center">
+                            <Text fontWeight="bold" mr={2}>
+                                Shipped on Date:
+                            </Text>
+                            <Text>
+                                {new Date(
+                                    order.external_metadata.tracking.data.soOrderInfo.createTime
+                                ).toLocaleString(undefined, {
+                                    year: 'numeric',
+                                    month: 'long',
+                                    day: 'numeric',
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                    second: '2-digit',
+                                })}
+                            </Text>
+                        </Flex>
+                    )}
                 </VStack>
 
                 {/* Right Column: Order ID & Chain Data */}
@@ -179,7 +190,11 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({
                         <strong>Order Chain:</strong>
                         {hasBitcoinPayment ? (
                             <>
-                                <Icon as={FaBitcoin} boxSize="20px" color="#F7931A" />
+                                <Icon
+                                    as={FaBitcoin}
+                                    boxSize="20px"
+                                    color="#F7931A"
+                                />
                                 <Text>Bitcoin</Text>
                             </>
                         ) : (

--- a/hamza-client/src/modules/order/templates/order-total-amount.tsx
+++ b/hamza-client/src/modules/order/templates/order-total-amount.tsx
@@ -1,14 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, Text, Icon } from '@chakra-ui/react';
 import currencyIcons from '@/images/currencies/crypto-currencies';
 import { formatCryptoPrice } from '@lib/util/get-product-price';
 import Image from 'next/image';
 import { convertPrice } from '@/lib/util/price-conversion';
 import { Spinner } from '@chakra-ui/react';
+import { FaBitcoin } from 'react-icons/fa';
 
 type PaymentTotal = {
     amount?: number | null;
     currency_code?: string;
+    metadata?: {
+        currency?: string;
+        amount?: string;
+        chainType?: string;
+        chainId?: string;
+    };
 };
 
 type OrderTotalAmountProps = {
@@ -27,6 +34,10 @@ const OrderTotalAmount: React.FC<OrderTotalAmountProps> = ({
     paymentTotal,
 }) => {
     const [usdPrice, setUsdPrice] = useState('');
+
+    const hasBitcoinPayment = paymentTotal?.metadata?.currency === 'btc';
+    const bitcoinAmount = paymentTotal?.metadata?.amount ?? '';
+
     useEffect(() => {
         const fetchConvertedPrice = async () => {
             if (subTotal && currencyCode.toLowerCase() === 'eth') {
@@ -76,20 +87,27 @@ const OrderTotalAmount: React.FC<OrderTotalAmountProps> = ({
                     <Text fontSize={'18px'} whiteSpace="nowrap">
                         {title}
                     </Text>
-                    <Image
-                        src={
-                            currencyIcons[currency_code.toLowerCase()] ??
-                            currencyIcons['usdc']
-                        }
-                        alt={currency_code.toUpperCase()}
-                        width={16}
-                        height={16}
-                    />
+                    {hasBitcoinPayment ? (
+                        <Icon as={FaBitcoin} boxSize="18px" color="#F7931A" />
+                    ) : (
+                        <Image
+                            src={
+                                currencyIcons[currency_code.toLowerCase()] ??
+                                currencyIcons['usdc']
+                            }
+                            alt={currency_code.toUpperCase()}
+                            width={16}
+                            height={16}
+                        />
+                    )}
                     <Text fontSize={'18px'} whiteSpace="nowrap">
-                        {getAmount(amount, currency_code)}
+                        {hasBitcoinPayment ?
+                            bitcoinAmount :
+                            getAmount(amount, currency_code)
+                        }
                     </Text>
                 </Flex>
-                {currencyCode === 'eth' && (
+                {currencyCode === 'eth' && !hasBitcoinPayment && (
                     <Flex alignItems="center" gap={2}>
                         {usdPrice === '' ? (
                             <Spinner size="sm" color="gray.300" />


### PR DESCRIPTION
**Motivation**

Once a bitcoin payment has been made by a customer, it shows up in the 

thankyou page 

orders panel 

as something other than a bitcoin payment. The fact that it has been paid in bitcoin is disguised by some other currency from which it was cross-calculated. This ain’t right. 

**Changes :** 

1. Added Bitcoin payment detection logic - Check payment metadata for currency === 'btc'
2. Updated Thank You page - Show Bitcoin icon + amount for "Total Amount Paid" section when Bitcoin payment detected
3. Updated Order Details page - Display "Bitcoin" with Bitcoin icon for "Order Chain" and show Bitcoin icon + amount for "Payment total" when Bitcoin payment detected


**Tests:**

1. Find any order
2. In that order's payment record in your local DB, set the 'metadata' field to include { “chainType”: “bitcoin”, “chainId”: “testnet”, “currency”: “btc”, “amount”: “0.0000128” } 
3. Check the thank you page for that order - "Total Amount Paid" should show Bitcoin icon + amount
4. Check the order details (customer orders panel) for that order - "Payment total" and "Order Chain" should show Bitcoin icon + "Bitcoin"


