### PR TITLE
HAMSTR-691 - allow currency select before login

### DIFF
--- a/hamza-client/src/app/components/providers/rainbowkit/rainbow-provider.tsx
+++ b/hamza-client/src/app/components/providers/rainbowkit/rainbow-provider.tsx
@@ -24,6 +24,7 @@ import {
     getHamzaCustomer,
     getToken,
     recoverCart,
+    setCurrency,
 } from '@/lib/server';
 import { signOut } from '@modules/account/actions';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
@@ -73,6 +74,7 @@ export function RainbowWrapper({ children }: { children: React.ReactNode }) {
     const {
         walletAddress,
         authData,
+        preferred_currency_code,
         setCustomerAuthData,
         setCustomerPreferredCurrency,
         setWhitelistConfig,
@@ -225,9 +227,15 @@ export function RainbowWrapper({ children }: { children: React.ReactNode }) {
                             status: 'authenticated',
                         });
 
-                        setCustomerPreferredCurrency(
-                            data.data?.preferred_currency?.code
-                        );
+                        // setCustomerPreferredCurrency(
+                        //     data.data?.preferred_currency?.code
+                        // );
+                        if (preferred_currency_code) {
+                            await setCurrency(
+                                preferred_currency_code,
+                                customerId
+                            );
+                        }
 
                         setWhitelistConfig(data.data?.whitelist_config);
 

--- a/hamza-client/src/modules/account/components/profile/components/profile-form/components/profile-currency.tsx
+++ b/hamza-client/src/modules/account/components/profile/components/profile-form/components/profile-currency.tsx
@@ -25,6 +25,7 @@ type ProfileCurrencyProps = {
     setCustomerPreferredCurrency: (currency: string) => void;
     isProfile?: boolean;
     className?: string;
+    iconOnly?: boolean;
 };
 
 const ProfileCurrency: React.FC<ProfileCurrencyProps> = ({
@@ -32,6 +33,7 @@ const ProfileCurrency: React.FC<ProfileCurrencyProps> = ({
     setCustomerPreferredCurrency,
     isProfile,
     className,
+    iconOnly = false,
 }) => {
     const currencies = [
         { code: 'usdc', label: 'USDC' },
@@ -78,9 +80,11 @@ const ProfileCurrency: React.FC<ProfileCurrencyProps> = ({
             <Menu>
                 <MenuButton
                     as={Button}
-                    rightIcon={<ChevronDownIcon />}
+                    rightIcon={iconOnly ? undefined : <ChevronDownIcon />}
                     borderRadius="12px"
                     height={{ base: '50px', md: '52px' }}
+                    width={iconOnly ? { base: '50px', md: '52px' } : 'auto'}
+                    minWidth={iconOnly ? { base: '50px', md: '52px' } : 'auto'}
                     backgroundColor="#020202"
                     border="none"
                     color="white"
@@ -96,10 +100,19 @@ const ProfileCurrency: React.FC<ProfileCurrencyProps> = ({
                                 width={20}
                                 height={20}
                             />
-                            <Text ml="8px">{currentCurrency.label}</Text>
+                            {!iconOnly && <Text ml="8px">{currentCurrency.label}</Text>}
                         </Flex>
                     ) : (
-                        'Select Currency'
+                        iconOnly ? (
+                            <Image
+                                alt="Select currency"
+                                src={currencyIcons['usdc']}
+                                width={20}
+                                height={20}
+                            />
+                        ) : (
+                            'Select Currency'
+                        )
                     )}
                 </MenuButton>
                 <MenuList backgroundColor="#020202" border="none">

--- a/hamza-client/src/modules/nav/components/nav-profile-currency/index.tsx
+++ b/hamza-client/src/modules/nav/components/nav-profile-currency/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import ProfileCurrency from '@/modules/account/components/profile/components/profile-form/components/profile-currency';
+import { useCustomerAuthStore } from '@store/customer-auth/customer-auth';
+
+type NavProfileCurrencyProps = {
+    iconOnly?: boolean;
+};
+
+const NavProfileCurrency: React.FC<NavProfileCurrencyProps> = ({ iconOnly = false }) => {
+    const preferred_currency_code = useCustomerAuthStore(
+        (state) => state.preferred_currency_code
+    );
+    const setCustomerPreferredCurrency = useCustomerAuthStore(
+        (state) => state.setCustomerPreferredCurrency
+    );
+    const authStatus = useCustomerAuthStore(
+        (state) => state.authData.status
+    );
+    const customerId = useCustomerAuthStore(
+        (state) => state.authData.customer_id
+    );
+
+    // Only show if user is not logged in (unauthenticated or no customer_id)
+    const isLoggedIn = authStatus === 'authenticated' && customerId;
+    
+    if (isLoggedIn) {
+        return null;
+    }
+
+    return (
+        <ProfileCurrency
+            preferredCurrencyCode={preferred_currency_code}
+            setCustomerPreferredCurrency={setCustomerPreferredCurrency}
+            iconOnly={iconOnly}
+            className="nav-currency-selector"
+        />
+    );
+};
+
+export default NavProfileCurrency;

--- a/hamza-client/src/modules/nav/templates/nav/index.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/index.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import LocalizedClientLink from '@modules/common/components/localized-client-link';
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 import Image from 'next/image';
 // Images
 //import HamzaLogo from '../../../../../public/images/logo/logo_green.svg';
@@ -17,6 +17,7 @@ import MobileMenu from './menu-mobile/menu/mobile-main-menu';
 import MobileNav from './menu-mobile/mobile-nav';
 import MainMenu from './menu-desktop/main-menu';
 import { WalletConnectButton } from './menu-desktop/connect-wallet';
+import NavProfileCurrency from '@modules/nav/components/nav-profile-currency';
 import { HiOutlineShoppingCart } from 'react-icons/hi';
 import { enrichLineItems, retrieveCart } from '@modules/cart/actions';
 import { LineItem } from '@medusajs/medusa';
@@ -88,9 +89,10 @@ export default async function Nav() {
 
                         <NavSearchBar />
 
-                        <Box ml={'auto'}>
+                        <Flex ml={'auto'} alignItems={'center'} gap={'12px'}>
+                            <NavProfileCurrency />
                             <WalletConnectButton />
-                        </Box>
+                        </Flex>
 
                         <Flex flexDirection={'row'} alignItems={'center'}>
                             <Flex alignSelf={'center'}>

--- a/hamza-client/src/modules/nav/templates/nav/menu-mobile/mobile-nav.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-mobile/mobile-nav.tsx
@@ -6,6 +6,7 @@ import HamzaLogo from '../../../../../../public/images/logo/logo_green.svg';
 import HamzaBetaTitle from '@/images/logo/hamza-title-beta.svg';
 import MobileMainMenu from './menu/mobile-main-menu';
 import { WalletConnectButton } from './connect-wallet/connect-button';
+import NavProfileCurrency from '@modules/nav/components/nav-profile-currency';
 import CartButtonMobile from './components/cart-button';
 
 export default async function MobileNav() {
@@ -46,7 +47,8 @@ export default async function MobileNav() {
                 </Flex>
 
                 <Flex flex={1}>
-                    <Flex ml="auto">
+                    <Flex ml="auto" alignItems={'center'} gap={'0px'}>
+                        <NavProfileCurrency iconOnly={true} />
                         <WalletConnectButton />
                         <CartButtonMobile />
                     </Flex>
@@ -54,7 +56,6 @@ export default async function MobileNav() {
                 <Flex>
                     <MobileMainMenu />
                 </Flex>
-
             </Flex>
         </Flex>
     );


### PR DESCRIPTION
Problem:
Currency selector was only available after login OR in the cart page.  In order to bring currency selector into the forefront, the idea is to move the selector into the navigation bar.

Solution:
Using the code from the cart page, we can refactor and move it into the navbar for use.

**Test:**
Currency Selector before logging in:
1. Test the currency selector in desktop and mobile before logging in

Selected currency after logging in:
2. Make sure the currency stays the same as the currency before logging in