### PR TITLE
HAMSTR-702 - switch network error display

### DIFF
--- a/hamza-client/src/modules/nav/templates/nav/menu-desktop/chain-selector-dropdown/index.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-desktop/chain-selector-dropdown/index.tsx
@@ -26,6 +26,7 @@ import {
     getChainInfoLinkUrlFromName,
     getChainLogoFromName,
 } from '@/modules/chain-select';
+import toast from 'react-hot-toast';
 
 const ChainDropdown: React.FC = () => {
     const { chain } = useNetwork();
@@ -41,6 +42,16 @@ const ChainDropdown: React.FC = () => {
             setActiveChainName(chain.name);
         }
     }, [isSuccess, chain?.name]);
+
+    // Show error toast when network switching fails
+    React.useEffect(() => {
+        if (error) {
+            toast.error(`Failed to switch network: ${error.message}`, {
+                duration: 5000,
+                position: 'bottom-right',
+            });
+        }
+    }, [error]);
 
     // Determine the learn more URL based on the active chain.
     const learnMoreUrl =

--- a/hamza-client/src/modules/nav/templates/nav/menu-mobile/components/chain-selector-dropdown.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-mobile/components/chain-selector-dropdown.tsx
@@ -20,11 +20,21 @@ import {
     getChainIdFromName,
     getChainLogoFromName,
 } from '@/modules/chain-select';
+import toast from 'react-hot-toast';
 
 const ChainDropdown: React.FC = () => {
     const { chain } = useNetwork();
     const { switchNetwork, isLoading, pendingChainId, error } =
         useSwitchNetwork();
+
+    React.useEffect(() => {
+        if (error) {
+            toast.error(`Failed to switch network: ${error.message}`, {
+                duration: 5000,
+                position: 'bottom-right',
+            });
+        }
+    }, [error]);
 
     return (
         <Menu placement="bottom-end">

--- a/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/mobile-account-menu.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/mobile-account-menu.tsx
@@ -39,7 +39,6 @@ const MobileAccountMenu = () => {
                 height={'26px'}
                 borderRadius={'full'}
                 borderColor={'white'}
-                borderWidth={'1px'}
                 backgroundColor={'transparent'}
                 cursor={'pointer'}
                 position="relative"


### PR DESCRIPTION
Problem:
When switching chains, if an error occured, the error message is in the chain switch dropdown.  But since the dropdown hides after "clicking", the user doesn't really know what happened.

Solution:
Added toast to handle error display.

**Test:**
1. (optional in local test) - change the chain id chain-select chainMap (src/modules/chain-select/index.ts) to something other non-existent id
2. launch site
3. Test the chain selector for the incorrect chain you updated in (1)
4. Error should display as a toast on the bottom right of display

NOTE: Test on mobile as well.