### PR TITLE
HAMSTR-703 - Update wallet info mobile menu to use full width instead of fixed min…

### DIFF
--- a/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/wallet-info-menu-mobile.tsx
+++ b/hamza-client/src/modules/nav/templates/nav/menu-mobile/menu/wallet-info-menu-mobile.tsx
@@ -139,7 +139,7 @@ const WalletInfoMobile: React.FC<NewWalletInfoProps> = ({
                         border="none"
                         bg="transparent"
                         boxShadow="none"
-                        minW="432px"
+                        width="100vw"
                     >
                         <Box
                             bg="#121212"


### PR DESCRIPTION
Problem:
In mobile responsive view, when mobile is under a certain size, the right side of the page displays a white empty bar.

**Test:**
1. View page on mobile or mobile responsive in browser
2. login 
3. See if there is a horizontal scrollbar displaying and a white bar to the right of the page
