### PR TITLE
HAMSTR-712: Faulty BTC-USD Conversion on Orders Page

### DIFF
--- a/hamza-client/src/modules/order/components/transaction-details/index.tsx
+++ b/hamza-client/src/modules/order/components/transaction-details/index.tsx
@@ -52,8 +52,8 @@ const TransactionDetails: React.FC<CartTotalsProps> = ({ data }) => {
     React.useEffect(() => {
         const fetchConvertedPrice = async () => {
             const result = await convertPrice(
-                Number(formatCryptoPrice(grandTotal, 'eth')),
-                'eth',
+                Number(formatCryptoPrice(grandTotal, currencyCode)),
+                currencyCode,
                 'usdc'
             );
             const formattedResult = Number(result).toFixed(2);

--- a/hamza-client/src/modules/order/templates/order-total-amount.tsx
+++ b/hamza-client/src/modules/order/templates/order-total-amount.tsx
@@ -44,8 +44,8 @@ const OrderTotalAmount: React.FC<OrderTotalAmountProps> = ({
             if (subTotal && !currencyIsUsdStable(currencyCode)) {
                 try {
                     const result = await convertPrice(
-                        Number(formatCryptoPrice(subTotal, 'eth')),
-                        'eth',
+                        Number(formatCryptoPrice(subTotal, currencyCode)),
+                        currencyCode,
                         'usdc'
                     );
                     const formattedResult = Number(result).toFixed(2);


### PR DESCRIPTION
**Motivation**

In a customer's orders, if an order is a bitcoin payment, the USD equivalent is not showing the correct USD equivalent amount. 

**Changes**

'eth' was hard-coded as the conversion currency; should be currencyCode to account for either btc or eth. 

**To Test**

Look at any bitcoin order in customer orders panel. Verify the displayed USD equivalent price.