### PR TITLE
HAMSTR-590: Recreate Cart after Payment Cancel

### DIFF
--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -594,6 +594,23 @@ export async function createCart(data = {}) {
     return postSecure('/custom/cart', { data });
 }
 
+export async function copyCart(oldCartId: string) {
+    //get cart id and customer id
+    const headers = getMedusaHeaders(['cart']);
+    const token: any = decode(cookies().get('_medusa_jwt')?.value ?? '') ?? {
+        customer_id: '',
+    };
+    const customerId: string = token?.customer_id ?? '';
+    const newCartId = cookies().get('_medusa_cart_id')?.value;
+
+    //post
+    const cart = await postSecure('/custom/cart/copy', {
+        customer_id: customerId,
+        source_cart_id: oldCartId,
+        cart_id: newCartId,
+    });
+}
+
 export async function updateCart(cartId: string, data: StorePostCartsCartReq) {
     const headers = getMedusaHeaders(['cart']);
 
@@ -1532,7 +1549,9 @@ export async function setBestShippingAddress(
     return address ?? null;
 }
 
-export async function validateDiscountUsage(code: string): Promise<DiscountValidationResult> {
+export async function validateDiscountUsage(
+    code: string
+): Promise<DiscountValidationResult> {
     try {
         const response = await get('/custom/discount/validate', { code });
         return response;
@@ -1542,7 +1561,11 @@ export async function validateDiscountUsage(code: string): Promise<DiscountValid
     }
 }
 
-export async function cancelPayments(paymentAddress: string, orderIds: string[], cartId: string) {
+export async function cancelPayments(
+    paymentAddress: string,
+    orderIds: string[],
+    cartId: string
+) {
     return putSecure('/custom/checkout/payment/cancel', {
         payment_address: paymentAddress,
         order_ids: orderIds,

--- a/hamza-client/src/lib/server/index.ts
+++ b/hamza-client/src/lib/server/index.ts
@@ -1561,14 +1561,22 @@ export async function validateDiscountUsage(
     }
 }
 
-export async function cancelPayments(
+export async function cancelPayment(
     paymentAddress: string,
     orderIds: string[],
     cartId: string
 ) {
+    //get customer id
+    const token: any = decode(cookies().get('_medusa_jwt')?.value ?? '') ?? {
+        customer_id: '',
+    };
+    const customerId: string = token?.customer_id ?? '';
+
+    //call api
     return putSecure('/custom/checkout/payment/cancel', {
         payment_address: paymentAddress,
         order_ids: orderIds,
         cart_id: cartId,
+        customer_id: customerId,
     });
 }

--- a/hamza-client/src/modules/order-confirmed/index.tsx
+++ b/hamza-client/src/modules/order-confirmed/index.tsx
@@ -80,7 +80,6 @@ interface OrderConfirmedProps {
 }
 
 const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
-
     // calculate totals
     const cartOrderTotal = orders.reduce(
         (total: number, order: ExtendedOrder) =>
@@ -133,9 +132,9 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
         let hasBitcoinPayment = false;
         let bitcoinAmount: string = '';
 
-        orders.forEach(order => {
+        orders.forEach((order) => {
             if (order.payments) {
-                order.payments.forEach(payment => {
+                order.payments.forEach((payment) => {
                     if (payment.metadata?.currency === 'btc') {
                         hasBitcoinPayment = true;
                         bitcoinAmount = payment.metadata.amount ?? '';
@@ -265,7 +264,12 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                             height={6}
                                             mr={2}
                                         />
-                                        <Text marginRight={2}>#...{order.id.replace(/^order_/, '').slice(-10)}</Text>
+                                        <Text marginRight={2}>
+                                            #...
+                                            {order.id
+                                                .replace(/^order_/, '')
+                                                .slice(-10)}
+                                        </Text>
                                         {order.store?.name}
                                     </Flex>
 
@@ -289,7 +293,8 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
 
                                 {order.items.map(
                                     (item: LineItem, itemIndex: number) => {
-                                        const productHandle = item.variant?.product?.handle;
+                                        const productHandle =
+                                            item.variant?.product?.handle;
 
                                         return (
                                             <Flex
@@ -299,7 +304,9 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                             >
                                                 <Flex gap={4} py={4}>
                                                     {productHandle ? (
-                                                        <LocalizedClientLink href={`/products/${productHandle}`}>
+                                                        <LocalizedClientLink
+                                                            href={`/products/${productHandle}`}
+                                                        >
                                                             <Box
                                                                 w="48px"
                                                                 h="48px"
@@ -307,17 +314,28 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                                                 borderRadius="8px"
                                                                 overflow="hidden"
                                                                 cursor="pointer"
-                                                                _hover={{ opacity: 0.8 }}
+                                                                _hover={{
+                                                                    opacity: 0.8,
+                                                                }}
                                                                 transition="opacity 0.2s"
                                                             >
                                                                 {item.thumbnail && (
                                                                     <Image
-                                                                        src={item.thumbnail}
-                                                                        alt={item.title}
-                                                                        width={48}
-                                                                        height={48}
+                                                                        src={
+                                                                            item.thumbnail
+                                                                        }
+                                                                        alt={
+                                                                            item.title
+                                                                        }
+                                                                        width={
+                                                                            48
+                                                                        }
+                                                                        height={
+                                                                            48
+                                                                        }
                                                                         style={{
-                                                                            objectFit: 'cover',
+                                                                            objectFit:
+                                                                                'cover',
                                                                         }}
                                                                     />
                                                                 )}
@@ -333,12 +351,17 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                                         >
                                                             {item.thumbnail && (
                                                                 <Image
-                                                                    src={item.thumbnail}
-                                                                    alt={item.title}
+                                                                    src={
+                                                                        item.thumbnail
+                                                                    }
+                                                                    alt={
+                                                                        item.title
+                                                                    }
                                                                     width={48}
                                                                     height={48}
                                                                     style={{
-                                                                        objectFit: 'cover',
+                                                                        objectFit:
+                                                                            'cover',
                                                                     }}
                                                                 />
                                                             )}
@@ -352,11 +375,15 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                                     >
                                                         {/* Clickable Title */}
                                                         {productHandle ? (
-                                                            <LocalizedClientLink href={`/products/${productHandle}`}>
+                                                            <LocalizedClientLink
+                                                                href={`/products/${productHandle}`}
+                                                            >
                                                                 <Text
                                                                     fontWeight="500"
                                                                     cursor="pointer"
-                                                                    _hover={{ color: '#94D42A' }}
+                                                                    _hover={{
+                                                                        color: '#94D42A',
+                                                                    }}
                                                                     transition="color 0.2s"
                                                                 >
                                                                     {item.title}
@@ -372,21 +399,24 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                                             color="gray.400"
                                                             fontSize="14px"
                                                         >
-                                                            Quantity: {item.quantity}
+                                                            Quantity:{' '}
+                                                            {item.quantity}
                                                             {item.variant &&
                                                                 ` | Variation: ${item.variant.title}`}
                                                         </Text>
                                                     </Flex>
                                                     <HStack
                                                         fontWeight="500"
-                                                        alignItems={'flex-start'}
+                                                        alignItems={
+                                                            'flex-start'
+                                                        }
                                                     >
                                                         <Image
                                                             className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] mt-[2px]"
                                                             src={
                                                                 currencyIcons[
-                                                                order.currency_code ??
-                                                                'usdc'
+                                                                    order.currency_code ??
+                                                                        'usdc'
                                                                 ]
                                                             }
                                                             alt={
@@ -397,7 +427,7 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                                         <Text>
                                                             {formatCryptoPrice(
                                                                 item.unit_price *
-                                                                item.quantity,
+                                                                    item.quantity,
                                                                 order.currency_code
                                                             )}
                                                         </Text>
@@ -598,7 +628,11 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                         <Text>Total Amount Paid:</Text>
                         <HStack>
                             {hasBitcoinPayment ? (
-                                <Icon as={FaBitcoin} boxSize="18px" color="#F7931A" />
+                                <Icon
+                                    as={FaBitcoin}
+                                    boxSize="18px"
+                                    color="#F7931A"
+                                />
                             ) : (
                                 <Image
                                     className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
@@ -607,7 +641,12 @@ const OrderConfirmed: React.FC<OrderConfirmedProps> = ({ params, orders }) => {
                                 />
                             )}
                             <Text>
-                                {hasBitcoinPayment ? bitcoinAmount : formatCryptoPrice(totalPaid, currencyCode)}
+                                {hasBitcoinPayment
+                                    ? bitcoinAmount
+                                    : formatCryptoPrice(
+                                          totalPaid,
+                                          currencyCode
+                                      )}
                             </Text>
                         </HStack>
                     </Flex>

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -42,7 +42,7 @@ import { formatCryptoPrice } from '@/lib/util/get-product-price';
 import { STATUS_STEPS } from './types';
 import {
     cancelOrder,
-    cancelPayments,
+    cancelPayment,
     copyCart,
     getPaymentData,
 } from '@/lib/server';
@@ -186,7 +186,7 @@ const OrderProcessing = ({
         try {
             const orderIds = ordersToCancel.map((order) => order.id);
             // Call the server function to cancel the payment
-            const result = await cancelPayments(
+            const result = await cancelPayment(
                 paymentData.paymentAddress,
                 orderIds,
                 cartId

--- a/hamza-client/src/modules/order-processing/index.tsx
+++ b/hamza-client/src/modules/order-processing/index.tsx
@@ -22,7 +22,13 @@ import {
     AlertDialogContent,
     AlertDialogOverlay,
 } from '@chakra-ui/react';
-import { FaBitcoin, FaCopy, FaQrcode, FaRegCheckCircle, FaTimes } from 'react-icons/fa';
+import {
+    FaBitcoin,
+    FaCopy,
+    FaQrcode,
+    FaRegCheckCircle,
+    FaTimes,
+} from 'react-icons/fa';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import StatusStep from './components/StatusStep';
@@ -34,7 +40,12 @@ import Image from 'next/image';
 import currencyIcons from '@/images/currencies/crypto-currencies';
 import { formatCryptoPrice } from '@/lib/util/get-product-price';
 import { STATUS_STEPS } from './types';
-import { cancelOrder, cancelPayments, getPaymentData } from '@/lib/server';
+import {
+    cancelOrder,
+    cancelPayments,
+    copyCart,
+    getPaymentData,
+} from '@/lib/server';
 import { useAccount } from 'wagmi';
 import { ModalCoverWalletConnect } from '../common/components/modal-cover-wallet-connect';
 import { calculateStepState } from './utils';
@@ -79,7 +90,7 @@ const OrderProcessing = ({
     const {
         isOpen: isCancelDialogOpen,
         onOpen: onCancelDialogOpen,
-        onClose: onCancelDialogClose
+        onClose: onCancelDialogClose,
     } = useDisclosure();
     const [isCanceling, setIsCanceling] = useState(false);
     const totalOrders = initialPaymentData?.orders?.length ?? 0;
@@ -173,24 +184,32 @@ const OrderProcessing = ({
         }
 
         try {
-
-            const orderIds = ordersToCancel.map(order => order.id);
+            const orderIds = ordersToCancel.map((order) => order.id);
             // Call the server function to cancel the payment
-            const result = await cancelPayments(paymentData.paymentAddress, orderIds, cartId);
+            const result = await cancelPayments(
+                paymentData.paymentAddress,
+                orderIds,
+                cartId
+            );
 
             if (result) {
-
                 toast({
                     title: 'Payment Canceled',
-                    description: 'Your payment has been successfully canceled. Redirecting to cart...',
+                    description:
+                        'Your payment has been successfully canceled. Redirecting to cart...',
                     status: 'success',
                     duration: 3000,
                     isClosable: true,
                 });
 
+                //copy a new cart
+                await copyCart(cartId);
+
                 // Update local state to reflect cancellation
                 setCurrentStatus('canceled');
-                setPaymentData(prev => prev ? { ...prev, status: 'expired' } : null);
+                setPaymentData((prev) =>
+                    prev ? { ...prev, status: 'expired' } : null
+                );
 
                 // Redirect to cart after a short delay
                 setTimeout(() => {
@@ -203,7 +222,10 @@ const OrderProcessing = ({
             console.error('Error canceling payment:', error);
             toast({
                 title: 'Cancellation Failed',
-                description: error instanceof Error ? error.message : 'Failed to cancel payment. Please try again.',
+                description:
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to cancel payment. Please try again.',
                 status: 'error',
                 duration: 5000,
                 isClosable: true,
@@ -298,7 +320,10 @@ const OrderProcessing = ({
                         setCurrentStatus(payment?.status);
 
                         // Stop polling if payment is expired or canceled
-                        if (payment.status === 'expired' || payment.status === 'canceled') {
+                        if (
+                            payment.status === 'expired' ||
+                            payment.status === 'canceled'
+                        ) {
                             clearInterval(timer);
                             return;
                         }
@@ -372,10 +397,10 @@ const OrderProcessing = ({
                                             currentStatus === 'expired'
                                                 ? 'red.900'
                                                 : currentStatus === 'partial'
-                                                    ? 'orange.900'
-                                                    : currentStatus === 'canceled'
-                                                        ? 'gray.700'
-                                                        : 'green.900'
+                                                  ? 'orange.900'
+                                                  : currentStatus === 'canceled'
+                                                    ? 'gray.700'
+                                                    : 'green.900'
                                         }
                                         px={3}
                                         py={1}
@@ -386,29 +411,30 @@ const OrderProcessing = ({
                                             currentStatus === 'expired'
                                                 ? 'red.500'
                                                 : currentStatus === 'partial'
-                                                    ? 'orange.400'
-                                                    : currentStatus === 'canceled'
-                                                        ? 'gray.500'
-                                                        : 'primary.green.900'
+                                                  ? 'orange.400'
+                                                  : currentStatus === 'canceled'
+                                                    ? 'gray.500'
+                                                    : 'primary.green.900'
                                         }
                                     >
                                         <Text color="white" fontWeight="bold">
                                             {currentStatus === 'expired'
                                                 ? 'Expired'
                                                 : currentStatus === 'partial'
-                                                    ? 'Partial'
-                                                    : currentStatus === 'canceled'
-                                                        ? 'Canceled'
-                                                        : STATUS_STEPS.find(
-                                                            (step) =>
-                                                                step.status ===
-                                                                currentStatus
-                                                        )?.label}
+                                                  ? 'Partial'
+                                                  : currentStatus === 'canceled'
+                                                    ? 'Canceled'
+                                                    : STATUS_STEPS.find(
+                                                          (step) =>
+                                                              step.status ===
+                                                              currentStatus
+                                                      )?.label}
                                         </Text>
                                     </Box>
 
                                     {/* Cancel Button - show if payment is waiting or partial */}
-                                    {(currentStatus === 'waiting' || currentStatus === 'partial') && (
+                                    {(currentStatus === 'waiting' ||
+                                        currentStatus === 'partial') && (
                                         <Button
                                             size="sm"
                                             bg="red.600"
@@ -433,7 +459,9 @@ const OrderProcessing = ({
                                     (step, index) =>
                                         (step.status === currentStatus ||
                                             (step.status === 'waiting' &&
-                                                (currentStatus === 'expired' || currentStatus === 'canceled'))) && (
+                                                (currentStatus === 'expired' ||
+                                                    currentStatus ===
+                                                        'canceled'))) && (
                                             <StatusStep
                                                 key={step.status}
                                                 step={step}
@@ -496,7 +524,7 @@ const OrderProcessing = ({
                                             {new Date(
                                                 paymentData?.orders?.length
                                                     ? paymentData.orders[0]
-                                                        ?.created_at
+                                                          ?.created_at
                                                     : ''
                                             )
                                                 .toLocaleDateString('en-US', {
@@ -527,8 +555,8 @@ const OrderProcessing = ({
                                                         className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
                                                         src={
                                                             currencyIcons[
-                                                            currencyCode ??
-                                                            'usdc'
+                                                                currencyCode ??
+                                                                    'usdc'
                                                             ]
                                                         }
                                                         alt={
@@ -552,9 +580,9 @@ const OrderProcessing = ({
                                                         <>
                                                             {formatCryptoPrice(
                                                                 paymentTotal ??
-                                                                0,
+                                                                    0,
                                                                 currencyCode ??
-                                                                'usdc',
+                                                                    'usdc',
                                                                 false
                                                             )}{' '}
                                                             {paymentCurrency?.toUpperCase()}{' '}
@@ -563,14 +591,14 @@ const OrderProcessing = ({
                                                                 .includes(
                                                                     'usd'
                                                                 ) && (
-                                                                    <>
-                                                                        ≅ $
-                                                                        {
-                                                                            convertedUsdTotal
-                                                                        }{' '}
-                                                                        USD
-                                                                    </>
-                                                                )}
+                                                                <>
+                                                                    ≅ $
+                                                                    {
+                                                                        convertedUsdTotal
+                                                                    }{' '}
+                                                                    USD
+                                                                </>
+                                                            )}
                                                         </>
                                                     )}
                                                 </Text>
@@ -603,17 +631,17 @@ const OrderProcessing = ({
                                                 onClick={() => {
                                                     const formattedAmount =
                                                         paywith === 'bitcoin'
-                                                            ? (formatNativeBtc(
+                                                            ? formatNativeBtc(
                                                                   paymentData?.expectedAmount
                                                               ) ??
-                                                              convertedBtcTotal)
+                                                              convertedBtcTotal
                                                             : formatCryptoPrice(
-                                                                paymentTotal ??
-                                                                0,
-                                                                currencyCode ??
-                                                                'usdc',
-                                                                false
-                                                            ).toString();
+                                                                  paymentTotal ??
+                                                                      0,
+                                                                  currencyCode ??
+                                                                      'usdc',
+                                                                  false
+                                                              ).toString();
                                                     navigator.clipboard.writeText(
                                                         formattedAmount ?? ''
                                                     );
@@ -794,7 +822,7 @@ const OrderProcessing = ({
                                             onClick={() => {
                                                 navigator.clipboard.writeText(
                                                     paymentData?.paymentAddress ??
-                                                    ''
+                                                        ''
                                                 );
                                                 setHasCopiedAddress(true);
                                                 setTimeout(
@@ -825,13 +853,18 @@ const OrderProcessing = ({
                     >
                         <AlertDialogOverlay>
                             <AlertDialogContent bg="gray.800" color="white">
-                                <AlertDialogHeader fontSize="lg" fontWeight="bold">
+                                <AlertDialogHeader
+                                    fontSize="lg"
+                                    fontWeight="bold"
+                                >
                                     Cancel Payment
                                 </AlertDialogHeader>
 
                                 <AlertDialogBody>
-                                    Are you sure you want to cancel this payment? This action cannot be undone.
-                                    You will be redirected back to your cart and can restart the checkout process later.
+                                    Are you sure you want to cancel this
+                                    payment? This action cannot be undone. You
+                                    will be redirected back to your cart and can
+                                    restart the checkout process later.
                                 </AlertDialogBody>
 
                                 <AlertDialogFooter>
@@ -976,7 +1009,7 @@ const OrderProcessing = ({
                                                                         )?.toString();
                                                                     navigator.clipboard.writeText(
                                                                         formattedAmount ??
-                                                                        ''
+                                                                            ''
                                                                     );
                                                                     setHasCopiedAmount(
                                                                         true
@@ -1017,8 +1050,8 @@ const OrderProcessing = ({
                                                                 className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
                                                                 src={
                                                                     currencyIcons[
-                                                                    currencyCode ??
-                                                                    'usdc'
+                                                                        currencyCode ??
+                                                                            'usdc'
                                                                     ]
                                                                 }
                                                                 alt={
@@ -1034,9 +1067,9 @@ const OrderProcessing = ({
                                                             >
                                                                 {formatCryptoPrice(
                                                                     paymentTotal ??
-                                                                    0,
+                                                                        0,
                                                                     currencyCode ??
-                                                                    'usdc',
+                                                                        'usdc',
                                                                     false
                                                                 )}{' '}
                                                                 {paymentCurrency?.toUpperCase()}
@@ -1072,9 +1105,9 @@ const OrderProcessing = ({
                                                                     const formattedAmount =
                                                                         formatCryptoPrice(
                                                                             paymentTotal ??
-                                                                            0,
+                                                                                0,
                                                                             currencyCode ??
-                                                                            'usdc',
+                                                                                'usdc',
                                                                             false
                                                                         ).toString();
                                                                     navigator.clipboard.writeText(
@@ -1192,7 +1225,7 @@ const OrderProcessing = ({
                                                 onClick={() => {
                                                     navigator.clipboard.writeText(
                                                         paymentData?.paymentAddress ??
-                                                        ''
+                                                            ''
                                                     );
                                                     setHasCopiedAddress(true);
                                                     setTimeout(
@@ -1253,22 +1286,23 @@ const OrderProcessing = ({
                                             className="h-[14px] w-[14px] md:h-[18px] md:w-[18px] self-center"
                                             src={
                                                 currencyIcons[
-                                                currencyCode ?? 'usdc'
+                                                    currencyCode ?? 'usdc'
                                                 ]
                                             }
                                             alt={currencyCode ?? 'usdc'}
                                         />
                                         <Text ml="0.4rem" color="white">
                                             {paywith === 'bitcoin'
-                                                ? `${formatNativeBtc(
-                                                    paymentData?.expectedAmount
-                                                ) ?? convertedBtcTotal
-                                                } BTC`
+                                                ? `${
+                                                      formatNativeBtc(
+                                                          paymentData?.expectedAmount
+                                                      ) ?? convertedBtcTotal
+                                                  } BTC`
                                                 : formatCryptoPrice(
-                                                    paymentTotal ?? 0,
-                                                    currencyCode ?? 'usdc',
-                                                    false
-                                                )}
+                                                      paymentTotal ?? 0,
+                                                      currencyCode ?? 'usdc',
+                                                      false
+                                                  )}
                                         </Text>
                                         {!currencyIsUsdStable(currencyCode) && (
                                             <Text ml="0.4rem" color="white">


### PR DESCRIPTION
**Motivation**

Here’s the scenario: you are checking out. You click “Pay with External Wallet”. You come to the Payment Processing screen. You realize that you chose the wrong chain (or something). Or maybe you realized that you need more time to pay. What you want to do is cancel the payment, recover your cart, then come back when you’re ready. 

What you can do, now, is just let the payment expire, then re-create your cart, and then check out again later. But it would be nice if you didn’t have to do all those steps. 

---

NOTE: test in conjunction with https://github.com/LoadPipe/hamza-backend/pull/102

---

**Changes** 

- added a new API route call to /custom/cart/copy; this will copy the old deactivated cart's items into the newly created cart
- called that API route after successful payment cancel

---

**To Test**
- add items to cart 
- go to check out 
- choose Pay with External Wallet or Pay with Bitcoin 
- click the Cancel Payment button 
- verify that your cart items from before are recovered 
- verify that your _medusa_cart_id cookie has changed 
- verify that you can complete a checkout with the new cart 
- verify that the DB history trail is preserved (old cart is deactivated, new cart has performed a checkout, no payment_address has been overwritten)
