### PR TITLE
HAMSTR-672 - added button for going to payment processing page from order history

### DIFF
--- a/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
+++ b/hamza-client/src/modules/order/templates/dynamic-order-status.tsx
@@ -7,10 +7,12 @@ const DynamicOrderStatus = ({
     orderDate,
     paymentStatus,
     paymentType: paymentType,
+    cartId,
 }: {
     orderDate?: string;
     paymentStatus?: string;
     paymentType?: string;
+    cartId?: string;
 }) => {
     const capitalizeFirstLetter = (str?: string) =>
         str ? str.replace(/(?:^|\s)\S/g, (match) => match.toUpperCase()) : '';
@@ -53,7 +55,26 @@ const DynamicOrderStatus = ({
             >
                 <LuBox width="18px" height="20px" />
 
-                <Text>Payment {capitalizeFirstLetter(paymentStatus)}</Text>
+                {paymentStatus === 'awaiting' && cartId ? (
+                    <a
+                        href={`http://localhost:8000/en/order/processing/${cartId}?paywith=evm&openqrmodal=true&checkout=true`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                            background: '#94D42A',
+                            color: 'black',
+                            border: 'none',
+                            borderRadius: '16px',
+                            padding: '4px 12px',
+                            fontWeight: 'bold',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        Payment Awaiting
+                    </a>
+                ) : (
+                    <Text>Payment {capitalizeFirstLetter(paymentStatus)}</Text>
+                )}
 
                 <IoMdInformationCircleOutline
                     color="94D42A"

--- a/hamza-client/src/modules/order/templates/orders/processing-order.tsx
+++ b/hamza-client/src/modules/order/templates/orders/processing-order.tsx
@@ -69,6 +69,7 @@ const ProcessingOrder = ({ order }: { order: any }) => {
                             )}
                             paymentStatus={order.payment_status}
                             paymentType={'Processing'}
+                            cartId={order.cart_id}
                         />
                     ) : null}
                     {/*item: {item.id} <br />*/}


### PR DESCRIPTION
Chose to go this route, when payment_status is awaiting:
![image](https://github.com/user-attachments/assets/36ec9146-740a-4d6c-8e5a-0e8887b4c3bd)

**Test:**
1. Create an external wallet payment
2. Go back to order history -> processing
3. There is a button where the text "Payment Awaiting" is displayed on top right corner of an order.