### PR TITLE
HAMSTR-756 : Background Square on Category Icons on Mouseover

### DIFF
--- a/hamza-client/src/modules/categories/components/category-grid.tsx
+++ b/hamza-client/src/modules/categories/components/category-grid.tsx
@@ -62,25 +62,34 @@ export default function CategoryGrid() {
                         key={cat.name}
                         href={`/category/${cat.handle}`}
                         className="
+                                    group
                                     flex 
                                     flex-col 
                                     items-center 
                                     rounded-xl 
                                     px-0 py-6
                                     transition-all
+                                    duration-300
+                                    ease-in-out
                                     w-full
+                                    hover:scale-105
+                                    transform
+                                    cursor-pointer
+                                    hover:bg-[#3A3A3A]
                                 "
                         style={{ backgroundColor: '#0B0A0B' }}
                     >
-                        <Image
-                            src={cat.icon}
-                            alt={cat.name}
-                            width={64}
-                            height={64}
-                            className="mb-3"
-                            draggable={false}
-                        />
-                        <span className="text-white text-lg font-medium text-center">
+                        <div className="transition-transform duration-300 ease-in-out group-hover:scale-110 mb-3">
+                            <Image
+                                src={cat.icon}
+                                alt={cat.name}
+                                width={64}
+                                height={64}
+                                className="transition-all duration-300"
+                                draggable={false}
+                            />
+                        </div>
+                        <span className="text-white text-lg font-medium text-center transition-all duration-300">
                             {cat.name}
                         </span>
                     </Link>

--- a/hamza-client/src/modules/categories/components/category-grid.tsx
+++ b/hamza-client/src/modules/categories/components/category-grid.tsx
@@ -65,13 +65,12 @@ export default function CategoryGrid() {
                                     flex 
                                     flex-col 
                                     items-center 
-                                    bg-black 
                                     rounded-xl 
                                     px-0 py-6
-                                    hover:bg-zinc-900 
                                     transition-all
                                     w-full
                                 "
+                        style={{ backgroundColor: '#0B0A0B' }}
                     >
                         <Image
                             src={cat.icon}


### PR DESCRIPTION
**Changes:**

1. Fixed background color mismatch between category icons and container
2. Set container background to #0B0A0B to match icon backgrounds
3. Removed hover:bg-zinc-900 that caused visible box effect

Test:

1. Hover over category icons on homepage
2. Verify no visible box appears around images
3. Check hover transition works smoothly