### PR TITLE
HAMSTR-759: No-address checkout

### DIFF
--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -28,6 +28,7 @@ import compareSelectedAddress from '@/lib/util/compare-address-select';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCustomerAuthStore } from '@store/customer-auth/customer-auth';
 import { useCartStore } from '@/zustand/cart-store/cart-store';
+import { isShippingAddressRequired } from '../../utils';
 
 interface AddressModalProps {
     isOpen: boolean;
@@ -64,7 +65,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
     const [emailError, setEmailError] = useState<string>('');
     const [phoneError, setPhoneError] = useState<string>('');
     const [shippingAddressRequired, setShippingAddressRequired] =
-        useState<boolean>(false);
+        useState<boolean>(true);
 
     const [formData, setFormData] = useState({
         'shipping_address.first_name': '',
@@ -123,22 +124,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
         }
     }, [isOpen, cart]);
 
-    const isShippingAddressRequired = () => {
-        if (cart?.items?.length == 0) return true;
-
-        for (let n = 0; n < (cart?.items?.length ?? 0); n++) {
-            if (
-                cart?.items[
-                    n
-                ].variant.product.metadata?.no_shipping_address?.toString() !==
-                'true'
-            ) {
-                return true;
-            }
-        }
-        return false;
-    };
-
     useEffect(() => {
         // If in edit mode and customer has addresses, compare current address to address book
         if (addressType === 'edit' && customer?.shipping_addresses) {
@@ -149,8 +134,15 @@ const AddressModal: React.FC<AddressModalProps> = ({
             setSavedAddressId(
                 matchingAddress?.id ? matchingAddress.id : selectedAddressId
             );
-            setShippingAddressRequired(isShippingAddressRequired());
         }
+
+        const shippingAddressRequired = isShippingAddressRequired(cart);
+        console.log(
+            'full shipping address is',
+            shippingAddressRequired ? '' : 'not',
+            'required'
+        );
+        setShippingAddressRequired(shippingAddressRequired);
     }, [cart, countryCode, addressType, customer, selectedAddressId]);
 
     const validateEmail = (email: string): boolean => {

--- a/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
+++ b/hamza-client/src/modules/checkout/components/payment/components/payment-button/index.tsx
@@ -41,6 +41,7 @@ import {
 import ChainSelectionInterstitial from '../chain-selector';
 import { useCustomerAuthStore } from '@/zustand/customer-auth/customer-auth';
 import { getCurrencyPrecision } from '@/currency.config';
+import { isShippingAddressRequired } from '@/modules/checkout/utils';
 
 //TODO: we need a global common function to replace this
 
@@ -449,10 +450,33 @@ const CryptoPaymentButton = ({
         await proceedWithPayment(paymentMode, chainType);
     };
 
+    const isMissingShippingAddress = (cart: any) => {
+        //if no shipping address, then definitely it's missing
+        if (!cart.shipping_address) return true;
+
+        //if shipping address is required, then we have to have the full address
+        if (isShippingAddressRequired(cart)) {
+            if (
+                !cart.shipping_address.first_name ||
+                !cart.shipping_address.last_name ||
+                !cart.shipping_address.address_1 ||
+                !cart.shipping_address.city ||
+                !cart.shipping_address.postal_code ||
+                !cart.shipping_address.country_code
+            ) {
+                return true;
+            }
+        }
+
+        //email is always required
+        console.log('cart email is', cart.email);
+        return cart.email?.length ? false : true;
+    };
+
     const searchParams = useSearchParams();
     const step = searchParams.get('step');
     const isCartEmpty = cart?.items.length === 0;
-    const isMissingAddress = !cart?.shipping_address; //TODO: fix this
+    const isMissingAddress = isMissingShippingAddress(cart);
     const isMissingShippingMethod = cart?.shipping_methods?.length === 0;
     const disableButton =
         isCartEmpty ||

--- a/hamza-client/src/modules/checkout/utils/index.ts
+++ b/hamza-client/src/modules/checkout/utils/index.ts
@@ -1,0 +1,15 @@
+export function isShippingAddressRequired(cart: any): boolean {
+    if (cart?.items?.length == 0) return true;
+
+    for (let n = 0; n < (cart?.items?.length ?? 0); n++) {
+        if (
+            cart?.items[
+                n
+            ].variant.product.metadata?.no_shipping_address?.toString() !==
+            'true'
+        ) {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
**Motivation** 
If a user is checking out with all digital items only in their their cart, then they should not be required to fill in a full shipping address. 

--- 

**Changes**

---

**To Test**
- Create one or more digital items in your local database by adding this to the product's metadata: (table product, column metadata): {"no_shipping_address":"true"}
- Add a digital item to your cart 
- Go to checkout 
- Verify that you are only required to add email address, in order to be allowed to checkout 
- Do not check out yet 
- Add another item to your cart, but make it a non-digital item 
- Go to checkout 
- Verify that you are again required to fill out shipping address, but this time you must enter full shipping address 
- Verify that you can now complete checkout 
- Verify that you are able to complete checkout with a cart that contains only digital items, entering only an email address. 

