### PR TITLE
HAMSTR-783 : Update CategoryCard to include dynamic href for category links

### DIFF
--- a/hamza-client/src/modules/giftcards-promo/components/category-section.tsx
+++ b/hamza-client/src/modules/giftcards-promo/components/category-section.tsx
@@ -23,6 +23,7 @@ interface CategoryCardProps {
     subtitle: string;
     color: string;
     bgGradient: string;
+    href: string;
     index: number;
     isVisible: boolean;
 }
@@ -34,20 +35,23 @@ const categories = [
         subtitle: 'Popular',
         color: 'purple',
         bgGradient: 'linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(168, 85, 247, 0.2))',
+        href: '/category/gift-cards?subcategory=gaming',
     },
     {
         icon: ShoppingBag,
-        title: 'E-commerce',
+        title: 'Home',
         subtitle: 'Popular',
         color: 'blue',
         bgGradient: 'linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(99, 102, 241, 0.2))',
+        href: '/category/gift-cards?subcategory=home',
     },
     {
         icon: Tv,
-        title: 'Streaming',
+        title: 'Entertainment',
         subtitle: 'Popular',
         color: 'red',
         bgGradient: 'linear-gradient(135deg, rgba(239, 68, 68, 0.2), rgba(220, 38, 127, 0.2))',
+        href: '/category/gift-cards?subcategory=entertainment',
     },
     {
         icon: Coffee,
@@ -55,6 +59,7 @@ const categories = [
         subtitle: 'Popular',
         color: 'orange',
         bgGradient: 'linear-gradient(135deg, rgba(251, 146, 60, 0.2), rgba(249, 115, 22, 0.2))',
+        href: '/category/gift-cards?subcategory=restaurants',
     },
     {
         icon: Shirt,
@@ -62,17 +67,19 @@ const categories = [
         subtitle: 'Popular',
         color: 'pink',
         bgGradient: 'linear-gradient(135deg, rgba(236, 72, 153, 0.2), rgba(219, 39, 119, 0.2))',
+        href: '/category/gift-cards?subcategory=fashion',
     },
     {
         icon: Smartphone,
-        title: 'Technology',
+        title: 'Digital Goods',
         subtitle: 'Popular',
         color: 'green',
         bgGradient: 'linear-gradient(135deg, rgba(34, 197, 94, 0.2), rgba(22, 163, 74, 0.2))',
+        href: '/category/gift-cards?subcategory=digital-goods',
     },
 ];
 
-const CategoryCard = memo(({ icon, title, subtitle, color, index, isVisible }: CategoryCardProps) => {
+const CategoryCard = memo(({ icon, title, subtitle, color, href, index, isVisible }: CategoryCardProps) => {
     const [isHovered, setIsHovered] = useState(false);
     const [isIconHovered, setIsIconHovered] = useState(false);
     const [hasInitialAnimationCompleted, setHasInitialAnimationCompleted] = useState(false);
@@ -92,7 +99,7 @@ const CategoryCard = memo(({ icon, title, subtitle, color, index, isVisible }: C
     }, [isVisible, index]);
 
     return (
-        <Link href="/en/category/gift-cards" passHref>
+        <Link href={href} passHref>
             <VStack
                 spacing={2}
                 align="center"
@@ -326,6 +333,7 @@ const CategorySection = memo(() => {
                                 subtitle={category.subtitle}
                                 color={category.color}
                                 bgGradient={category.bgGradient}
+                                href={category.href}
                                 index={index}
                                 isVisible={isVisible}
                             />


### PR DESCRIPTION
**Motivation**

On the Giftcards Promo landing page, we have some links that should link to subcategories of giftcards; for now though they just link to the Giftcards category page root itself. But now that we have working subcategories, we can change them to point to the appropriate subcategories.

**Changes :**

1. Updated category links to point to specific subcategories with query parameters
2. Changed "E-commerce" to "Home" category
2. Changed "Streaming" to "Entertainment" category
3. Changed "Technology" to "Digital Goods" category
4. Added href prop to CategoryCard component

**Test :**

1. Click Gaming card → should navigate to /category/gift-cards?subcategory=gaming
2. Click Home card → should navigate to /category/gift-cards?subcategory=home
3. Click Entertainment card → should navigate to /category/gift-cards?subcategory=entertainment
4. Click Food & Drink card → should navigate to /category/gift-cards?subcategory=restaurants
5. Click Fashion card → should navigate to /category/gift-cards?subcategory=fashion
6. Click Digital Goods card → should navigate to /category/gift-cards?subcategory=digital-goods