### PR TITLE
HAMSTR-796 : ReadyCashCard Store page Subcategories go off the page

### DIFF
--- a/hamza-client/src/modules/store/components/store-cat-button.tsx
+++ b/hamza-client/src/modules/store/components/store-cat-button.tsx
@@ -32,8 +32,9 @@ const StoreCatButton: React.FC<StoreCatButtonProps> = ({ categoryName }) => {
 
     return (
         <Flex
-            px={'1rem'}
             minWidth={{ base: '94px', md: '167px' }}
+            px={{ base: '1rem', md: '1.5rem' }}
+            py={{ base: '0.75rem', md: '1rem' }}
             height={{ base: '42px', md: '66px' }}
             borderRadius={'49px'}
             borderWidth={'1px'}
@@ -43,8 +44,20 @@ const StoreCatButton: React.FC<StoreCatButtonProps> = ({ categoryName }) => {
             alignItems={'center'}
             cursor={'pointer'}
             onClick={() => toggleCategorySelection(categoryName)}
+            flexShrink={0}
+            whiteSpace={'nowrap'}
+            transition={'all 0.2s ease-in-out'}
+            _hover={{
+                borderColor: isSelected ? 'gray.300' : 'white',
+                transform: 'translateY(-1px)',
+            }}
         >
-            <Text fontSize={{ base: '10px', md: '16px' }}>
+            <Text
+                fontSize={{ base: '10px', md: '16px' }}
+                fontWeight={'medium'}
+                whiteSpace={'nowrap'}
+                textAlign={'center'}
+            >
                 {formattedCatName}
             </Text>
         </Flex>

--- a/hamza-client/src/modules/store/components/store-search.tsx
+++ b/hamza-client/src/modules/store/components/store-search.tsx
@@ -57,13 +57,36 @@ const StoreSearch = ({ storeName }: Props) => {
     return (
         <Flex flexDir={'column'} width={'100%'}>
             <Flex
-                mx={'1rem'}
-                flexDir={'row'}
-                maxWidth={'1256.52px'}
-                width={'100%'}
-                my={{ base: '1rem', md: '3rem' }}
-                gap={'1rem'}
+                position="relative"
+                mx={{ base: '1rem', md: '2rem' }}
+                flexDir="row"
+                maxWidth="1256.52px"
+                width="100%"
+                my={{ base: '1.5rem', md: '3rem' }}
+                gap="0.75rem"
                 className="store-filters"
+                overflowX="auto"
+                flexWrap="nowrap"
+                pb="0.5rem" 
+                sx={{
+                    '&::-webkit-scrollbar': {
+                        height: '6px',
+                    },
+                    '&::-webkit-scrollbar-track': {
+                        background: 'transparent',
+                        borderRadius: '10px',
+                    },
+                    '&::-webkit-scrollbar-thumb': {
+                        background: 'rgba(255, 255, 255, 0.3)',
+                        borderRadius: '10px',
+                        '&:hover': {
+                            background: 'rgba(255, 255, 255, 0.5)',
+                        },
+                    },
+                    scrollBehavior: 'smooth',
+                    scrollbarWidth: 'thin',
+                    scrollbarColor: 'rgba(255, 255, 255, 0.3) transparent',
+                }}
             >
                 <StoreCatButton categoryName={'All'} />
 


### PR DESCRIPTION
**Changes**

1. Added horizontal scrolling to category filters when too many categories overflow the page
2. Fixed category button text centering issues for long category names

**Test**

1. Navigate to a store page with many categories and verify horizontal scrolling works



