### PR TITLE
HAMSTR-826 : Address Handling still Confusing

### DIFF
--- a/hamza-client/src/modules/checkout/components/address-modal/index.tsx
+++ b/hamza-client/src/modules/checkout/components/address-modal/index.tsx
@@ -52,9 +52,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
 }) => {
     // Save address to address book if radio button clicked
     const [saveAddress, setSaveAddress] = useState(false);
-    const [saveAddressButtonText, setSaveAddressButtonText] = useState(
-        addressType === 'add' ? 'Add Address' : 'Edit Address'
-    );
     const [overwriteAddress, setOverwriteAddress] = useState(false);
     const [savedAddressID, setSavedAddressId] = useState('');
     const [selectedAddressId, setSelectedAddressId] = useState<string>('');
@@ -118,9 +115,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
             }
             setSaveAddress(false);
             setOverwriteAddress(false);
-            setSaveAddressButtonText(
-                addressType === 'add' ? 'Add Address' : 'Edit Address'
-            );
         }
     }, [isOpen, cart]);
 
@@ -241,8 +235,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
     ) => {
         setSaveAddress(e.target.checked);
         console.log('saved clicked', e.target.checked);
-        if (e.target.checked) setSaveAddressButtonText('Save Address');
-        else setSaveAddressButtonText('Edit Address');
     };
 
     const handleOverwriteAddressChange = (
@@ -250,8 +242,6 @@ const AddressModal: React.FC<AddressModalProps> = ({
     ) => {
         setOverwriteAddress(e.target.checked);
         console.log('overwrite clicked', e.target.checked);
-        if (e.target.checked) setSaveAddressButtonText('Overwrite');
-        else setSaveAddressButtonText('Save Address');
     };
 
     const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -722,7 +712,7 @@ const AddressModal: React.FC<AddressModalProps> = ({
                                 _hover={{ opacity: 0.5 }}
                                 type="submit"
                             >
-                                {saveAddressButtonText}
+                                Submit
                             </Button>
                         </Flex>
                     </ModalFooter>

--- a/hamza-client/src/modules/checkout/components/addresses/index.tsx
+++ b/hamza-client/src/modules/checkout/components/addresses/index.tsx
@@ -20,6 +20,7 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchCartForCart } from '@/app/[countryCode]/(main)/cart/utils/fetch-cart-for-cart';
 import { CartWithCheckoutStep } from '@/types/global';
 import { useCartStore } from '@/zustand/cart-store/cart-store';
+import { isShippingAddressRequired } from '@/modules/checkout/utils';
 
 //TODO: we need a global common function to replace this
 const MEDUSA_SERVER_URL =
@@ -77,6 +78,11 @@ const Addresses = ({
         setShippingAddressType('edit');
         onOpen();
     };
+
+    const shippingRequired = isShippingAddressRequired(cart);
+    
+    const addButtonText = shippingRequired ? 'Add Shipping Address' : 'Add Email Address';
+    const editButtonText = shippingRequired ? 'Edit Shipping Address' : 'Edit Email Address';
 
     // useEffect(() => {
     //     const updateShippingMethod = async () => {
@@ -191,7 +197,7 @@ const Addresses = ({
                                 }}
                                 onClick={handleEditAddress}
                             >
-                                Edit Shipping Address
+                                {editButtonText}
                             </Button>
                         </Flex>
                     </Flex>
@@ -216,7 +222,7 @@ const Addresses = ({
                             }}
                             onClick={handleAddAddress}
                         >
-                            Add Shipping Address
+                            {addButtonText}
                         </Button>
                     </Flex>
                 )}


### PR DESCRIPTION
**Motivation**

How to handle shipping addresses is still confusing to new users. 

**Changes:**

  1. Made payment button clickable when address is missing - now opens address modal directly instead of being disabled
  2. Changed address modal submit button to always say "Submit" instead of dynamic text (Add/Edit/Save/Overwrite)
  3. Updated address section buttons to show "Add/Edit Email Address" for digital products, "Add/Edit Shipping Address" for physical products

  **Test:**

  1. Add items to cart without address - payment button should be clickable and open address modal when clicked
  2. Open address modal - submit button should always show "Submit" regardless of add/edit/save checkbox state
  3. Test with digital products - address buttons should show "Add/Edit Email Address"
  4. Test with physical products - address buttons should show "Add/Edit Shipping Address"